### PR TITLE
Add top tracks, top albums and refine topartists

### DIFF
--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -203,6 +203,8 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
+            _ = this.Context.Channel.TriggerTypingAsync();
+
             if (num > 12)
             {
                 num = 12;

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -196,13 +196,6 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            if (!Enum.TryParse(time, true, out ChartTimePeriod timePeriod))
-            {
-                await ReplyAsync($"Invalid time period. Please use {Constants.ExpandedTimePeriodList}. \n" +
-                                 $"Usage: `{prfx}fmtopalbums '{Constants.CompactTimePeriodList}' 'number of albums (max 12)' 'lastfm username/discord user'`");
-                return;
-            }
-
             _ = this.Context.Channel.TriggerTypingAsync();
 
             if (num > 12)
@@ -214,6 +207,7 @@ namespace FMBot.Bot.Commands.LastFM
                 num = 1;
             }
 
+            var timePeriod = LastFMService.StringToChartTimePeriod(time);
             var timeSpan = LastFMService.ChartTimePeriodToLastStatsTimeSpan(timePeriod);
 
             try

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -13,6 +13,7 @@ using FMBot.Bot.Services;
 using FMBot.LastFM.Domain.Models;
 using FMBot.LastFM.Domain.Types;
 using FMBot.LastFM.Services;
+using FMBot.Persistence.Domain.Models;
 using ImageFormat = System.Drawing.Imaging.ImageFormat;
 
 namespace FMBot.Bot.Commands.LastFM
@@ -23,6 +24,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly EmbedAuthorBuilder _embedAuthor;
         private readonly EmbedFooterBuilder _embedFooter;
         private readonly LastFMService _lastFmService;
+        private readonly GuildService _guildService;
         private readonly ILastfmApi _lastfmApi;
         private readonly Logger.Logger _logger;
 
@@ -36,6 +38,7 @@ namespace FMBot.Bot.Commands.LastFM
             this._lastfmApi = lastfmApi;
             this._lastFmService = new LastFMService(lastfmApi);
             this._prefixService = prefixService;
+            this._guildService = new GuildService();
             this._userService = new UserService();
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -175,6 +178,131 @@ namespace FMBot.Bot.Commands.LastFM
 
             this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
                 this.Context.Message.Content);
+        }
+
+        [Command("topalbums", RunMode = RunMode.Async)]
+        [Summary("Displays top albums.")]
+        [Alias("abl", "abs", "tab", "albumlist", "albums", "albumslist")]
+        [LoginRequired]
+        public async Task ArtistsAsync(string time = "weekly", int num = 8, string user = null)
+        {
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.CommandPrefix;
+
+            if (time == "help")
+            {
+                await ReplyAsync(
+                    $"Usage: `{prfx}topalbums '{Constants.CompactTimePeriodList}' 'number of albums (max 12)' 'lastfm username/discord user'`");
+                return;
+            }
+
+            if (!Enum.TryParse(time, true, out ChartTimePeriod timePeriod))
+            {
+                await ReplyAsync($"Invalid time period. Please use {Constants.ExpandedTimePeriodList}. \n" +
+                                 $"Usage: `{prfx}fmtopalbums '{Constants.CompactTimePeriodList}' 'number of albums (max 12)' 'lastfm username/discord user'`");
+                return;
+            }
+
+            if (num > 12)
+            {
+                num = 12;
+            }
+            if (num < 1)
+            {
+                num = 1;
+            }
+
+            var timeSpan = LastFMService.ChartTimePeriodToLastStatsTimeSpan(timePeriod);
+
+            try
+            {
+                var lastFMUserName = userSettings.UserNameLastFM;
+                var self = true;
+
+                if (user != null)
+                {
+                    var alternativeLastFmUserName = await FindUser(user);
+                    if (!string.IsNullOrEmpty(alternativeLastFmUserName))
+                    {
+                        lastFMUserName = alternativeLastFmUserName;
+                        self = false;
+                    }
+                }
+
+                var albums = await this._lastFmService.GetTopAlbumsAsync(lastFMUserName, timeSpan, num);
+
+                if (albums?.Any() != true)
+                {
+                    this._embed.NoScrobblesFoundErrorResponse(albums.Status, this.Context, this._logger);
+                    await ReplyAsync("", false, this._embed.Build());
+                    return;
+                }
+
+                string userTitle;
+                if (self)
+                {
+                    userTitle = await this._userService.GetUserTitleAsync(this.Context);
+                }
+                else
+                {
+                    userTitle =
+                        $"{lastFMUserName}, requested by {await this._userService.GetUserTitleAsync(this.Context)}";
+                }
+
+                this._embedAuthor.WithIconUrl(this.Context.User.GetAvatarUrl());
+                var artistsString = num == 1 ? "album" : "albums";
+                this._embedAuthor.WithName($"Top {num} {timePeriod} {artistsString} for {userTitle}");
+                this._embedAuthor.WithUrl($"{Constants.LastFMUserUrl}{lastFMUserName}/library/albums?date_preset={LastFMService.ChartTimePeriodToSiteTimePeriodUrl(timePeriod)}");
+                this._embed.WithAuthor(this._embedAuthor);
+
+                var description = "";
+                for (var i = 0; i < albums.Count(); i++)
+                {
+                    var album = albums.Content[i];
+
+                    description += $"{i + 1}. {album.ArtistName} - [{album.Name}]({album.Url}) ({album.PlayCount} plays) \n";
+                }
+
+                this._embed.WithDescription(description);
+
+                var userInfo = await this._lastFmService.GetUserInfoAsync(lastFMUserName);
+
+                this._embedFooter.WithText(lastFMUserName + "'s total scrobbles: " +
+                                           userInfo.Content.Playcount.ToString("N0"));
+                this._embed.WithFooter(this._embedFooter);
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
+                    this.Context.Message.Content);
+            }
+            catch (Exception e)
+            {
+                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
+                    this.Context.Guild?.Name, this.Context.Guild?.Id);
+                await ReplyAsync("Unable to show Last.FM info due to an internal error.");
+            }
+        }
+
+        private async Task<string> FindUser(string user)
+        {
+            if (await this._lastFmService.LastFMUserExistsAsync(user))
+            {
+                return user;
+            }
+
+            if (!this._guildService.CheckIfDM(this.Context))
+            {
+                var guildUser = await this._guildService.FindUserFromGuildAsync(this.Context, user);
+
+                if (guildUser != null)
+                {
+                    var guildUserLastFm = await this._userService.GetUserSettingsAsync(guildUser);
+
+                    return guildUserLastFm?.UserNameLastFM;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -152,11 +152,11 @@ namespace FMBot.Bot.Commands.LastFM
                 this.Context.Message.Content);
         }
 
-        [Command("artists", RunMode = RunMode.Async)]
+        [Command("topartists", RunMode = RunMode.Async)]
         [Summary("Displays top artists.")]
-        [Alias("al", "as", "artistlist", "artistslist")]
+        [Alias("al", "as","ta", "artistlist","artists", "artistslist")]
         [LoginRequired]
-        public async Task ArtistsAsync(string time = "weekly", int num = 10, string user = null)
+        public async Task TopArtistsAsync(string time = "weekly", int num = 10, string user = null)
         {
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.CommandPrefix;
@@ -164,29 +164,27 @@ namespace FMBot.Bot.Commands.LastFM
             if (time == "help")
             {
                 await ReplyAsync(
-                    "Usage: `.fmartists 'weekly/monthly/yearly/alltime' 'number of artists (max 10)' 'lastfm username/discord user'` \n" +
-                    "You can set your default user and your display mode through the `.fmset 'username' 'embedfull/embedmini/textfull/textmini'` command.");
+                    $"Usage: `{prfx}artists '{Constants.CompactTimePeriodList}' 'number of artists (max 16)' 'lastfm username/discord user'`");
                 return;
             }
 
             if (!Enum.TryParse(time, true, out ChartTimePeriod timePeriod))
             {
-                await ReplyAsync("Invalid time period. Please use 'weekly', 'monthly', 'yearly', or 'alltime'. \n" +
-                                 "Usage: `.fmartists 'weekly/monthly/yearly/alltime' 'number of artists (max 10)' 'lastfm username/discord user'`");
+                await ReplyAsync($"Invalid time period. Please use {Constants.ExpandedTimePeriodList}. \n" +
+                                 $"Usage: `{prfx}artists '{Constants.CompactTimePeriodList}' 'number of artists (max 16)' 'lastfm username/discord user'`");
                 return;
             }
 
-            if (num > 20)
+            if (num > 16)
             {
-                num = 20;
+                num = 16;
             }
-
             if (num < 1)
             {
                 num = 1;
             }
 
-            var timeSpan = this._lastFmService.GetLastStatsTimeSpan(timePeriod);
+            var timeSpan = LastFMService.ChartTimePeriodToLastStatsTimeSpan(timePeriod);
 
             try
             {
@@ -226,7 +224,7 @@ namespace FMBot.Bot.Commands.LastFM
                 this._embedAuthor.WithIconUrl(this.Context.User.GetAvatarUrl());
                 var artistsString = num == 1 ? "artist" : "artists";
                 this._embedAuthor.WithName($"Top {num} {timePeriod} {artistsString} for {userTitle}");
-                this._embedAuthor.WithUrl(Constants.LastFMUserUrl + lastFMUserName + "/library/artists");
+                this._embedAuthor.WithUrl($"{Constants.LastFMUserUrl}{lastFMUserName}/library/artists?date_preset={LastFMService.ChartTimePeriodToSiteTimePeriodUrl(timePeriod)}");
                 this._embed.WithAuthor(this._embedAuthor);
 
                 var description = "";

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -168,13 +168,6 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            if (!Enum.TryParse(time, true, out ChartTimePeriod timePeriod))
-            {
-                await ReplyAsync($"Invalid time period. Please use {Constants.ExpandedTimePeriodList}. \n" +
-                                 $"Usage: `{prfx}artists '{Constants.CompactTimePeriodList}' 'number of artists (max 16)' 'lastfm username/discord user'`");
-                return;
-            }
-
             _ = this.Context.Channel.TriggerTypingAsync();
 
             if (num > 16)
@@ -186,6 +179,7 @@ namespace FMBot.Bot.Commands.LastFM
                 num = 1;
             }
 
+            var timePeriod = LastFMService.StringToChartTimePeriod(time);
             var timeSpan = LastFMService.ChartTimePeriodToLastStatsTimeSpan(timePeriod);
 
             try

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -175,6 +175,8 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
+            _ = this.Context.Channel.TriggerTypingAsync();
+
             if (num > 16)
             {
                 num = 16;
@@ -420,6 +422,7 @@ namespace FMBot.Bot.Commands.LastFM
             }
 
             _ = this.Context.Channel.TriggerTypingAsync();
+
             try
             {
                 var topGuildArtists = await this._artistsService.GetTopArtistsForGuild(guild.GuildUsers.Select(s => s.User).ToList());

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -58,7 +58,7 @@ namespace FMBot.Bot.Commands.LastFM
             var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.CommandPrefix;
             if (otherSettings.Any() && otherSettings.First() == "help")
             {
-                await ReplyAsync($"{prfx}chart '2x2-10x10' 'weekly/monthly/yearly/overall' \n" +
+                await ReplyAsync($"{prfx}chart '2x2-10x10' '{Constants.CompactTimePeriodList}' \n" +
                                  "Optional extra settings: 'notitles', 'nt', 'skipemptyimages', 's'\n" +
                                  "Options can be used in any order..");
                 return;
@@ -128,7 +128,7 @@ namespace FMBot.Bot.Commands.LastFM
                 {
                     var reply =
                         $"User hasn't listened to enough albums ({albums.Count()} of required {chartSettings.ImagesNeeded}) for a chart this size. " +
-                        "Please try a smaller chart or a bigger time period (weekly/monthly/yearly/overall)'.";
+                        $"Please try a smaller chart or a bigger time period ({Constants.CompactTimePeriodList})'.";
 
                     if (chartSettings.SkipArtistsWithoutImage)
                     {

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -420,13 +420,6 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            if (!Enum.TryParse(time, true, out ChartTimePeriod timePeriod))
-            {
-                await ReplyAsync($"Invalid time period. Please use {Constants.ExpandedTimePeriodList}. \n" +
-                                 $"Usage: `.fmtoptracks '{Constants.CompactTimePeriodList}' 'number of tracks (max 12)' 'lastfm username/discord user'`");
-                return;
-            }
-
             _ = this.Context.Channel.TriggerTypingAsync();
 
             if (num > 12)
@@ -438,6 +431,7 @@ namespace FMBot.Bot.Commands.LastFM
                 num = 1;
             }
 
+            var timePeriod = LastFMService.StringToChartTimePeriod(time);
             var timeSpan = LastFMService.ChartTimePeriodToCallTimePeriod(timePeriod);
 
             try

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -427,6 +427,8 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
+            _ = this.Context.Channel.TriggerTypingAsync();
+
             if (num > 12)
             {
                 num = 12;

--- a/src/FMBot.Bot/Resources/Constants.cs
+++ b/src/FMBot.Bot/Resources/Constants.cs
@@ -17,6 +17,10 @@ namespace FMBot.Bot.Resources
 
         public const string DocsUrl = "https://fmbot.xyz";
 
+        public const string CompactTimePeriodList = "weekly/monthly/quarterly/half/yearly/alltime";
+
+        public const string ExpandedTimePeriodList = "'weekly', 'monthly', 'quarterly', 'half', 'yearly', or 'alltime'";
+
         public static TimeSpan GuildIndexCooldown = TimeSpan.FromDays(2);
 
         /// <summary>Amount of users to index. Should always end with 000</summary>

--- a/src/FMBot.Bot/Services/ChartService.cs
+++ b/src/FMBot.Bot/Services/ChartService.cs
@@ -367,6 +367,18 @@ namespace FMBot.Bot.Services
                 chartSettings.TimespanString = "Monthly Chart";
                 chartSettings.TimespanUrlString = "LAST_30_DAYS";
             }
+            else if (extraOptions.Contains("quarterly") || extraOptions.Contains("quarter") || extraOptions.Contains("q"))
+            {
+                chartSettings.TimeSpan = LastStatsTimeSpan.Quarter;
+                chartSettings.TimespanString = "Quarterly Chart";
+                chartSettings.TimespanUrlString = "LAST_90_DAYS";
+            }
+            else if (extraOptions.Contains("halfyearly") || extraOptions.Contains("half") || extraOptions.Contains("h"))
+            {
+                chartSettings.TimeSpan = LastStatsTimeSpan.Year;
+                chartSettings.TimespanString = "Half-yearly Chart";
+                chartSettings.TimespanUrlString = "LAST_180_DAYS";
+            }
             else if (extraOptions.Contains("yearly") || extraOptions.Contains("year") || extraOptions.Contains("y"))
             {
                 chartSettings.TimeSpan = LastStatsTimeSpan.Year;

--- a/src/FMBot.Bot/Services/LastFMService.cs
+++ b/src/FMBot.Bot/Services/LastFMService.cs
@@ -148,7 +148,7 @@ namespace FMBot.Bot.Services
 
             var artistCall = await this._lastfmApi.CallApiAsync<ArtistResponse>(queryParams, Call.ArtistInfo);
             Statistics.LastfmApiCalls.Inc();
-            
+
             return artistCall;
         }
 
@@ -237,6 +237,26 @@ namespace FMBot.Bot.Services
             Statistics.LastfmApiCalls.Inc();
 
             return lastFMUser.Success;
+        }
+
+        public static ChartTimePeriod StringToChartTimePeriod(string timeString)
+        {
+            if (Enum.TryParse(timeString, true, out ChartTimePeriod timePeriod))
+            {
+                return timePeriod;
+            }
+
+            return timeString switch
+            {
+                "w" => ChartTimePeriod.Weekly,
+                "m" => ChartTimePeriod.Monthly,
+                "q" => ChartTimePeriod.Quarterly,
+                "h" => ChartTimePeriod.Half,
+                "y" => ChartTimePeriod.Yearly,
+                "a" => ChartTimePeriod.AllTime,
+                "overall" => ChartTimePeriod.AllTime,
+                _ => ChartTimePeriod.Weekly
+            };
         }
 
         public static LastStatsTimeSpan ChartTimePeriodToLastStatsTimeSpan(ChartTimePeriod timePeriod)

--- a/src/FMBot.LastFM.Domain/ResponseModels/TopTracks.cs
+++ b/src/FMBot.LastFM.Domain/ResponseModels/TopTracks.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using FMBot.LastFM.Domain.Models;
+
+namespace FMBot.LastFM.Domain.ResponseModels
+{
+    public class TopTracksResponse
+    {
+        public TopTracks TopTracks { get; set; }
+    }
+
+    public class TopTracks
+    {
+        public TopTracksAttr Attr { get; set; }
+        public List<Track> Track { get; set; }
+    }
+
+    public partial class TopTracksAttr
+    {
+        public long Page { get; set; }
+        public long Total { get; set; }
+        public string User { get; set; }
+        public long PerPage { get; set; }
+        public long TotalPages { get; set; }
+    }
+
+    public class Track
+    {
+        public long Duration { get; set; }
+        public long Playcount { get; set; }
+        public Artist Artist { get; set; }
+        public List<Image> Image { get; set; }
+        public string Mbid { get; set; }
+        public string Name { get; set; }
+        public Uri Url { get; set; }
+    }
+
+    public class Artist
+    {
+        public Uri Url { get; set; }
+        public string Name { get; set; }
+        public string Mbid { get; set; }
+    }
+}

--- a/src/FMBot.LastFM.Domain/Types/Calls.cs
+++ b/src/FMBot.LastFM.Domain/Types/Calls.cs
@@ -6,6 +6,7 @@ namespace FMBot.LastFM.Domain.Types
             ArtistInfo = "Artist.getInfo",
             AlbumInfo = "Album.getInfo",
             TrackInfo = "Track.getInfo",
-            UserInfo = "User.getInfo";
+            UserInfo = "User.getInfo",
+            TopTracks = "user.gettoptracks";
     }
 }

--- a/src/FMBot.LastFM.Domain/Types/TimePeriods.cs
+++ b/src/FMBot.LastFM.Domain/Types/TimePeriods.cs
@@ -1,0 +1,13 @@
+namespace FMBot.LastFM.Domain.Types
+{
+    public class TimePeriod
+    {
+        public const string
+            Overall = "overall",
+            Week = "7day",
+            Month = "1month",
+            Quarter = "3month",
+            Half = "6month",
+            Year = "12month";
+    }
+}

--- a/src/FMBot.Persistence.Domain/Models/ChartTimePeriod.cs
+++ b/src/FMBot.Persistence.Domain/Models/ChartTimePeriod.cs
@@ -1,4 +1,4 @@
-﻿namespace FMBot.Persistence.Domain.Models
+namespace FMBot.Persistence.Domain.Models
 {
     public enum ChartTimePeriod
     {
@@ -8,6 +8,10 @@
 
         Yearly = 3,
 
-        AllTime = 4
+        AllTime = 4,
+
+        Quarterly = 5,
+
+        Half = 6
     }
 }


### PR DESCRIPTION
Changelog
- Added .fmtoptracks (closes #71 )
- Added .fmtopalbums
- Changed .fmartists to .fmtopartists
- Added support for all time periods to above commands and .fmchart (closes #61 )
- Added support for time period shortcuts
- Title of embed links to last.fm site