### PR TITLE
Merge dev to main

### DIFF
--- a/src/FMBot.Bot/Commands/AdminCommands.cs
+++ b/src/FMBot.Bot/Commands/AdminCommands.cs
@@ -6,6 +6,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain;
 using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.Bot.Commands
@@ -149,6 +150,30 @@ namespace FMBot.Bot.Commands
             else
             {
                 await ReplyAsync("Error: Insufficient rights. Only FMBot admins can restart the bot.");
+            }
+        }
+
+        [Command("issues")]
+        [Summary("Toggles issue mode")]
+        public async Task IssuesAsync()
+        {
+            if (await this._adminService.HasCommandAccessAsync(this.Context.User, UserType.Admin))
+            {
+                if (!PublicProperties.IssuesAtLastFM)
+                {
+                    PublicProperties.IssuesAtLastFM = true;
+                    await ReplyAsync("Enabled issue mode");
+
+                }
+                else
+                {
+                    PublicProperties.IssuesAtLastFM = false;
+                    await ReplyAsync("Disabled issue mode");
+                }
+            }
+            else
+            {
+                await ReplyAsync("Error: Insufficient rights. Only FMBot admins can change issue mode.");
             }
         }
 

--- a/src/FMBot.Bot/Commands/AdminCommands.cs
+++ b/src/FMBot.Bot/Commands/AdminCommands.cs
@@ -76,7 +76,9 @@ namespace FMBot.Bot.Commands
 
             description += $"Friends: `{userSettings.Friends.Count}`\n";
             description += $"Befriended by: `{userSettings.FriendedByUsers.Count}`\n";
-            description += $"Indexed artists: `{userSettings.Artists.Count}`";
+            //description += $"Indexed artists: `{userSettings.Artists.Count}`";
+            //description += $"Indexed albums: `{userSettings.Albums.Count}`";
+            //description += $"Indexed tracks: `{userSettings.Tracks.Count}`";
 
             this._embed.WithDescription(description);
             await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);

--- a/src/FMBot.Bot/Commands/FriendsCommands.cs
+++ b/src/FMBot.Bot/Commands/FriendsCommands.cs
@@ -30,14 +30,15 @@ namespace FMBot.Bot.Commands
         public FriendsCommands(Logger.Logger logger,
             IPrefixService prefixService,
             ILastfmApi lastfmApi,
-            GuildService guildService)
+            GuildService guildService,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._guildService = guildService;
             this._userService = new UserService();
             this._friendsService = new FriendsService();
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();

--- a/src/FMBot.Bot/Commands/FriendsCommands.cs
+++ b/src/FMBot.Bot/Commands/FriendsCommands.cs
@@ -6,9 +6,11 @@ using Dasync.Collections;
 using Discord;
 using Discord.Commands;
 using FMBot.Bot.Attributes;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 using FMBot.LastFM.Services;
 
 namespace FMBot.Bot.Commands
@@ -61,6 +63,7 @@ namespace FMBot.Bot.Commands
                 {
                     await ReplyAsync("We couldn't find any friends. To add friends:\n" +
                                      "`.fmaddfriends 'lastfmname/discord name'`");
+                    this.Context.LogCommandUsed(CommandResponse.NotFound);
                     return;
                 }
 
@@ -129,14 +132,11 @@ namespace FMBot.Bot.Commands
                 this._embed.WithDescription(embedDescription);
 
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
-
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Unable to show friends due to an internal error.");
             }
@@ -151,12 +151,14 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Sorry, but adding friends in dms is not supported.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
             if (enteredFriends.Length == 0)
             {
                 await ReplyAsync("Please enter at least one friend to add. You can use their last.fm usernames, discord mention or discord id.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -171,6 +173,7 @@ namespace FMBot.Bot.Commands
                 if (existingFriends.Count + enteredFriends.Length > 10)
                 {
                     await ReplyAsync("Sorry, but you can't have more than 10 friends.");
+                    this.Context.LogCommandUsed(CommandResponse.WrongInput);
                     return;
                 }
 
@@ -240,15 +243,11 @@ namespace FMBot.Bot.Commands
 
                 this._embed.WithDescription(reply);
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
-
+                this.Context.LogCommandException(e);
                 await ReplyAsync("Unable to add friend(s) due to an internal error.");
             }
         }
@@ -264,6 +263,7 @@ namespace FMBot.Bot.Commands
             if (enteredFriends.Length == 0)
             {
                 await ReplyAsync("Please enter at least one friend to remove. You can use their last.fm usernames, discord mention or discord id.");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -326,15 +326,11 @@ namespace FMBot.Bot.Commands
 
                 this._embed.WithDescription(reply);
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
-
+                this.Context.LogCommandException(e);
                 await ReplyAsync("Unable to remove friend(s) due to an internal error. Please contact .fmbot staff.");
             }
         }
@@ -352,14 +348,11 @@ namespace FMBot.Bot.Commands
                 await this._friendsService.RemoveAllLastFMFriendsAsync(userSettings.UserId);
 
                 await ReplyAsync("Removed all your friends.");
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
-
+                this.Context.LogCommandException(e);
                 await ReplyAsync("Unable to remove all friends due to an internal error.");
             }
         }

--- a/src/FMBot.Bot/Commands/GeniusCommands.cs
+++ b/src/FMBot.Bot/Commands/GeniusCommands.cs
@@ -25,12 +25,15 @@ namespace FMBot.Bot.Commands
 
         private readonly IPrefixService _prefixService;
 
-        public GeniusCommands(Logger.Logger logger, IPrefixService prefixService, ILastfmApi lastfmApi)
+        public GeniusCommands(Logger.Logger logger,
+            IPrefixService prefixService,
+            ILastfmApi lastfmApi,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._userService = new UserService();
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedFooter = new EmbedFooterBuilder();

--- a/src/FMBot.Bot/Commands/GeniusCommands.cs
+++ b/src/FMBot.Bot/Commands/GeniusCommands.cs
@@ -5,9 +5,11 @@ using Discord;
 using Discord.Commands;
 using FMBot.Bot.Attributes;
 using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 using FMBot.LastFM.Services;
 
 namespace FMBot.Bot.Commands
@@ -65,6 +67,7 @@ namespace FMBot.Bot.Commands
                     {
                         this._embed.NoScrobblesFoundErrorResponse(tracks.Status, this.Context, this._logger);
                         await ReplyAsync("", false, this._embed.Build());
+                        this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                         return;
                     }
 
@@ -92,17 +95,17 @@ namespace FMBot.Bot.Commands
 
                     await ReplyAsync("", false, this._embed.Build());
 
-                    this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id,
-                        this.Context.User.Id, this.Context.Message.Content);
+                    this.Context.LogCommandUsed();
                 }
                 else
                 {
                     await ReplyAsync("No results have been found for this track.");
+                    this.Context.LogCommandUsed(CommandResponse.NotFound);
                 }
             }
             catch (Exception e)
             {
-                this._logger.LogException(this.Context.Message.Content, e);
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Unable to show Last.FM info via Genius due to an internal error. " +
                     "Try setting a Last.FM name with the 'fmset' command, scrobbling something, and then use the command again.");

--- a/src/FMBot.Bot/Commands/GuildCommands.cs
+++ b/src/FMBot.Bot/Commands/GuildCommands.cs
@@ -8,6 +8,7 @@ using Discord.Commands;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.Bot.Commands

--- a/src/FMBot.Bot/Commands/GuildCommands.cs
+++ b/src/FMBot.Bot/Commands/GuildCommands.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
@@ -54,6 +55,7 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -63,6 +65,7 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "You are not authorized to use this command. Only users with the 'Ban Members' permission, server admins or FMBot admins can use this command.");
+                this.Context.LogCommandUsed(CommandResponse.NoPermission);
                 return;
             }
 
@@ -70,6 +73,7 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "Sets the global default for your server. `.fmserverset 'embedfull/embedmini/textfull/textmini' 'Weekly/Monthly/Yearly/AllTime'` command.");
+                this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
 
@@ -77,6 +81,7 @@ namespace FMBot.Bot.Commands
             if (!Enum.TryParse(chartType, true, out FmEmbedType chartTypeEnum))
             {
                 await ReplyAsync("Invalid mode. Please use 'embedmini', 'embedfull', 'textfull', or 'textmini'.");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -84,6 +89,7 @@ namespace FMBot.Bot.Commands
             if (!Enum.TryParse(chartTimePeriod, true, out ChartTimePeriod chartTimePeriodEnum))
             {
                 await ReplyAsync("Invalid mode. Please use 'weekly', 'monthly', 'yearly', or 'overall'.");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -91,7 +97,7 @@ namespace FMBot.Bot.Commands
 
             await ReplyAsync("The .fmset default chart type for your server has been set to " + chartTypeEnum +
                              " with the time period " + chartTimePeriodEnum + ".");
-            this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id, this.Context.Message.Content);
+            this.Context.LogCommandUsed();
         }
 
         [Command("serverreactions", RunMode = RunMode.Async)]
@@ -102,6 +108,7 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -111,12 +118,14 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "You are not authorized to use this command. Only users with the 'Ban Members' permission, server admins or FMBot admins can use this command.");
+                this.Context.LogCommandUsed(CommandResponse.NoPermission);
                 return;
             }
 
             if (emotes.Count() > 3)
             {
                 await ReplyAsync("Sorry, max amount emote reactions you can set is 3!");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -125,6 +134,7 @@ namespace FMBot.Bot.Commands
                 await this._guildService.SetGuildReactionsAsync(this.Context.Guild, null);
                 await ReplyAsync(
                     "Removed all server reactions!");
+                this.Context.LogCommandUsed();
                 return;
             }
 
@@ -133,6 +143,7 @@ namespace FMBot.Bot.Commands
                 await ReplyAsync(
                     "Sorry, one or multiple of your reactions seems invalid. Please try again.\n" +
                     "Please check if you have a space between every emote.");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -141,7 +152,7 @@ namespace FMBot.Bot.Commands
             var message = await ReplyAsync("Emote reactions have been set! \n" +
                                            "Please check if all reactions have been applied to this message correctly. If not, you might have used an emote from a different server.");
             await this._guildService.AddReactionsAsync(message, this.Context.Guild);
-            this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id, this.Context.Message.Content);
+            this.Context.LogCommandUsed();
         }
 
         [Command("export", RunMode = RunMode.Async)]
@@ -152,6 +163,7 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -161,6 +173,7 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "You are not authorized to use this command. Only users with the 'Ban Members' permission, server admins or FMBot admins can use this command.");
+                this.Context.LogCommandUsed(CommandResponse.NoPermission);
                 return;
             }
 
@@ -171,6 +184,7 @@ namespace FMBot.Bot.Commands
                 if (serverUsers.Count == 0)
                 {
                     await ReplyAsync("No members found on this server.");
+                    this.Context.LogCommandUsed(CommandResponse.NotFound);
                     return;
                 }
 
@@ -183,15 +197,16 @@ namespace FMBot.Bot.Commands
                 await this.Context.User.SendFileAsync(StringToStream(userJson),
                     $"users_{this.Context.Guild.Name}_UTC-{DateTime.UtcNow:u}.json");
 
+                await ReplyAsync("Check your DMs!");
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Something went wrong while creating an export.");
             }
 
-            await ReplyAsync("Check your DMs!");
-            this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id, this.Context.Message.Content);
         }
 
         /// <summary>
@@ -204,6 +219,7 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -213,6 +229,7 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "You are not authorized to use this command. Only users with the 'Ban Members' permission, server admins or FMBot admins can use this command.");
+                this.Context.LogCommandUsed(CommandResponse.NoPermission);
                 return;
             }
 
@@ -221,6 +238,7 @@ namespace FMBot.Bot.Commands
                 await this._guildService.SetGuildPrefixAsync(this.Context.Guild, null);
                 this._prefixService.RemovePrefix(this.Context.Guild.Id);
                 await ReplyAsync("Removed prefix!");
+                this.Context.LogCommandUsed();
                 return;
             }
             if (prefix.ToLower() == ".fm")
@@ -228,17 +246,20 @@ namespace FMBot.Bot.Commands
                 await this._guildService.SetGuildPrefixAsync(this.Context.Guild, null);
                 this._prefixService.RemovePrefix(this.Context.Guild.Id);
                 await ReplyAsync("Reset to default prefix `.fm`!");
+                this.Context.LogCommandUsed();
                 return;
             }
 
             if (prefix.Length > 20)
             {
                 await ReplyAsync("Max prefix length is 20 characters...");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
             if (prefix.Contains("*") || prefix.Contains("`") || prefix.Contains("~"))
             {
                 await ReplyAsync("You can't have a custom prefix that contains ** * **or **`** or **~**");
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -256,7 +277,7 @@ namespace FMBot.Bot.Commands
                                         $"To remove the custom prefix, do `{prefix}prefix remove`");
 
             await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
-            this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id, this.Context.Message.Content);
+            this.Context.LogCommandUsed();
         }
 
 
@@ -270,6 +291,7 @@ namespace FMBot.Bot.Commands
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("Command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -294,6 +316,7 @@ namespace FMBot.Bot.Commands
 
                 this._embed.WithDescription(description);
                 await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
+                this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
 
@@ -303,6 +326,7 @@ namespace FMBot.Bot.Commands
             {
                 await ReplyAsync(
                     "You are not authorized to toggle commands. Only users with the 'Ban Members' permission, server admins or FMBot admins disable/enable commands.");
+                this.Context.LogCommandUsed(CommandResponse.NoPermission);
                 return;
             }
 
@@ -313,6 +337,7 @@ namespace FMBot.Bot.Commands
                 this._embed.WithDescription("No commands found or command can't be disabled.\n" +
                                             "Remember to remove the `.fm` prefix.");
                 await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
+                this.Context.LogCommandUsed(CommandResponse.WrongInput);
                 return;
             }
 
@@ -334,7 +359,7 @@ namespace FMBot.Bot.Commands
             }
 
             await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
-            this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id, this.Context.Message.Content);
+            this.Context.LogCommandUsed();
         }
 
         private static Stream StringToStream(string str)

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -103,16 +103,17 @@ namespace FMBot.Bot.Commands
 
                 this._embed.WithTitle($"Added {users.Count} {usersString} to bot indexing queue");
 
-                var expectedTime = TimeSpan.FromSeconds(7 * users.Count);
+                var expectedTime = TimeSpan.FromSeconds(8 * users.Count);
                 var indexStartedReply =
                     $"Indexing stores which .fmbot members are on your server and stores their initial top artist, albums and tracks. Updating these records happens automatically, but you can also use `.fmupdate` to update your own account.\n\n" +
-                    $"`{users.Count}` new users or users that have never been index added to index queue.";
+                    $"`{users.Count}` new users or users that have never been indexed added to index queue.";
 
                 indexStartedReply += $"\n`{indexedUserCount}` users already indexed on this server.\n \n";
 
                 if (expectedTime.TotalMinutes >= 1)
                 {
-                    indexStartedReply += $"**This will take approximately {(int)expectedTime.TotalMinutes} minutes. Commands might display incomplete results until this process is done.**\n";
+                    indexStartedReply += $"**This will take approximately {(int)expectedTime.TotalMinutes} minutes. \n" +
+                                         $"⚠️ Commands might display incomplete results until this process is done.**\n";
                 }
 
                 indexStartedReply += "*Note: You will currently not be alerted when the index is finished.*";

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -155,10 +155,24 @@ namespace FMBot.Bot.Commands
             }
             else
             {
+                this._embed.WithDescription($"<a:loading:748652128502939778> Updating user {userSettings.UserNameLastFM}...");
+                var message = await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+
                 await this._updateService.UpdateUser(userSettings);
+
+
+                await message.ModifyAsync(m =>
+                {
+                    m.Embed = new EmbedBuilder()
+                        .WithDescription($"✔️ {userSettings.UserNameLastFM} has been updated.")
+                        .WithColor(Constants.SuccessColorGreen)
+                        .Build();
+                });
+
+
+                Console.WriteLine("Test");
             }
 
-            await ReplyAsync("You have been updated");
         }
     }
 }

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -3,9 +3,12 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using FMBot.Bot.Attributes;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 
 namespace FMBot.Bot.Commands
 {
@@ -16,30 +19,34 @@ namespace FMBot.Bot.Commands
         private readonly UserService _userService;
         private readonly IIndexService _indexService;
         private readonly IUpdateService _updateService;
-        private readonly Logger.Logger _logger;
 
-        public IndexCommands(Logger.Logger logger,
+        private readonly IPrefixService _prefixService;
+
+        public IndexCommands(
             IIndexService indexService,
             IUpdateService updateService,
             GuildService guildService,
-            UserService userService)
+            UserService userService,
+            IPrefixService prefixService)
         {
-            this._logger = logger;
             this._indexService = indexService;
             this._updateService = updateService;
             this._guildService = guildService;
             this._userService = userService;
+            this._prefixService = prefixService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
         }
 
         [Command("index", RunMode = RunMode.Async)]
         [Summary("Indexes top artists, albums and tracks for every user in your server.")]
+        [Alias("i")]
         public async Task IndexGuildAsync()
         {
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("This command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
                 return;
             }
 
@@ -53,15 +60,13 @@ namespace FMBot.Bot.Commands
                 var users = await this._indexService.GetUsersToIndex(guildUsers);
                 var indexedUserCount = await this._indexService.GetIndexedUsersCount(guildUsers);
 
-                var guildOnCooldown =
-                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-Constants.GuildIndexCooldown);
-
                 var guildRecentlyIndexed =
-                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(3));
+                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(5));
 
                 if (guildRecentlyIndexed)
                 {
                     await ReplyAsync("An index was recently started on this server. Please wait before running this command again.");
+                    this.Context.LogCommandUsed(CommandResponse.Cooldown);
                     return;
                 }
                 if (users.Count == 0 && lastIndex != null)
@@ -69,16 +74,11 @@ namespace FMBot.Bot.Commands
                     await this._indexService.StoreGuildUsers(this.Context.Guild, guildUsers);
 
                     var reply =
-                        $"No new registered .fmbot members found on this server or all users have already been indexed in the last {Constants.GuildIndexCooldown.TotalHours} hours.\n" +
+                        $"No new registered .fmbot members found on this server or all users have already been indexed. Note that updating users happens automatically, but you can also manually update yourself using `.fmupdate`.\n" +
                         $"Stored guild users have been updated.";
 
-                    if (guildOnCooldown)
-                    {
-                        var timeTillIndex = lastIndex.Value.Add(Constants.GuildIndexCooldown) - DateTime.UtcNow;
-                        reply +=
-                            $"\nAll users in this server can be updated again in {(int)timeTillIndex.TotalHours} hours and {timeTillIndex:mm} minutes";
-                    }
                     await ReplyAsync(reply);
+                    this.Context.LogCommandUsed(CommandResponse.Cooldown);
                     return;
                 }
                 if (users.Count == 0 && lastIndex == null)
@@ -87,14 +87,11 @@ namespace FMBot.Bot.Commands
                     await this._guildService.UpdateGuildIndexTimestampAsync(this.Context.Guild, DateTime.UtcNow.AddDays(-1));
                     await ReplyAsync("All users on this server have already been indexed or nobody is registered on .fmbot here.\n" +
                                      "The server has now been registered anyway, so you can start using the commands that require indexing.");
+                    this.Context.LogCommandUsed();
+                    return;
                 }
 
                 string usersString = "";
-                if (guildOnCooldown)
-                {
-                    usersString = "new ";
-                }
-
                 if (users.Count == 1)
                 {
                     usersString += "user";
@@ -106,18 +103,19 @@ namespace FMBot.Bot.Commands
 
                 this._embed.WithTitle($"Added {users.Count} {usersString} to bot indexing queue");
 
-                var expectedTime = TimeSpan.FromSeconds(2 * users.Count);
+                var expectedTime = TimeSpan.FromSeconds(7 * users.Count);
                 var indexStartedReply =
-                    $"Indexing stores users their all time top {Constants.ArtistsToIndex} artists. \n\n" +
-                    $"`{users.Count}` new users or users with expired artists added to queue.";
+                    $"Indexing stores which .fmbot members are on your server and stores their initial top artist, albums and tracks. Updating these records happens automatically, but you can also use `.fmupdate` to update your own account.\n\n" +
+                    $"`{users.Count}` new users or users that have never been index added to index queue.";
 
-                if (expectedTime.TotalMinutes >= 2)
+                indexStartedReply += $"\n`{indexedUserCount}` users already indexed on this server.\n \n";
+
+                if (expectedTime.TotalMinutes >= 1)
                 {
-                    indexStartedReply += $" This will take approximately {(int)expectedTime.TotalMinutes} minutes.";
+                    indexStartedReply += $"**This will take approximately {(int)expectedTime.TotalMinutes} minutes. Commands might display incomplete results until this process is done.**\n";
                 }
 
-                indexStartedReply += $"\n`{indexedUserCount}` users already indexed on this server.\n \n" +
-                                     "*Note: You will currently not be alerted when the index is finished.*";
+                indexStartedReply += "*Note: You will currently not be alerted when the index is finished.*";
 
                 this._embed.WithDescription(indexStartedReply);
 
@@ -125,16 +123,15 @@ namespace FMBot.Bot.Commands
 
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
 
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
 
                 await this._indexService.StoreGuildUsers(this.Context.Guild, guildUsers);
+
                 this._indexService.IndexGuild(users);
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Something went wrong while indexing users. Please let us know as this feature is in beta.");
                 await this._guildService.UpdateGuildIndexTimestampAsync(this.Context.Guild, DateTime.UtcNow);
@@ -144,15 +141,48 @@ namespace FMBot.Bot.Commands
         [Command("update", RunMode = RunMode.Async)]
         [Summary("Update user.")]
         [LoginRequired]
+        [Alias("u")]
         public async Task UpdateUserAsync(string force = null)
         {
-            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
-
-
-            if (force != null && (force.ToLower() == "f" || force.ToLower() == "-f" || force.ToLower() == "full"))
+            var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.Bot.Prefix;
+            if (force == "help")
             {
-                this._embed.WithDescription($"<a:loading:748652128502939778> Fully indexing user {userSettings.UserNameLastFM}..." +
-                                            $"\nThis can take a while. Please don't fully update too often, if you have any issues with the normal update feel free to let us know.");
+                this._embed.WithTitle($"{prfx}update");
+                this._embed.WithDescription($"Updates your top artists/albums/genres based on your latest scrobbles.\n" +
+                                            $"Add `full` to fully update your account in case you edited your scrobble history.\n" +
+                                            $"Note that updating also happens automatically.");
+
+                this._embed.AddField("Examples",
+                    $"`{prfx}update\n" +
+                    $"`{prfx}update full`");
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+                this.Context.LogCommandUsed(CommandResponse.Help);
+                return;
+            }
+
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            if (userSettings.LastUpdated > DateTime.UtcNow.AddMinutes(-3))
+            {
+                await ReplyAsync(
+                    "You have already been updated recently. Note that this also happens automatically.");
+                this.Context.LogCommandUsed(CommandResponse.Cooldown);
+                return;
+            }
+
+            if (force != null && (force.ToLower() == "f" || force.ToLower() == "-f" || force.ToLower() == "full" || force.ToLower() == "-force" || force.ToLower() == "force"))
+            {
+                if (userSettings.LastUpdated < DateTime.UtcNow.AddDays(-2))
+                {
+                    await ReplyAsync(
+                        "You can't do a full index too often. Please remember that this command should only be used in case you edited your scrobble history.\n" +
+                        "Experiencing issues with the normal update? Please contact us on the .fmbot support server.");
+                    this.Context.LogCommandUsed(CommandResponse.Cooldown);
+                    return;
+                }
+
+                this._embed.WithDescription($"<a:loading:749715170682470461> Fully indexing user {userSettings.UserNameLastFM}..." +
+                                            $"\n\nThis can take a while. Please don't fully update too often, if you have any issues with the normal update feel free to let us know.");
 
                 var message = await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
 
@@ -168,7 +198,15 @@ namespace FMBot.Bot.Commands
             }
             else
             {
-                this._embed.WithDescription($"<a:loading:748652128502939778> Updating user {userSettings.UserNameLastFM}...");
+                if (userSettings.LastIndexed == null)
+                {
+                    await ReplyAsync(
+                        "You have to be indexed before you can update. (`.fmupdate full`)");
+                    this.Context.LogCommandUsed(CommandResponse.IndexRequired);
+                    return;
+                }
+
+                this._embed.WithDescription($"<a:loading:749715170682470461> Updating user {userSettings.UserNameLastFM}...");
                 var message = await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
 
                 var scrobblesUsed = await this._updateService.UpdateUser(userSettings);
@@ -182,6 +220,7 @@ namespace FMBot.Bot.Commands
                 });
             }
 
+            this.Context.LogCommandUsed();
         }
     }
 }

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -61,7 +61,7 @@ namespace FMBot.Bot.Commands
                 var indexedUserCount = await this._indexService.GetIndexedUsersCount(guildUsers);
 
                 var guildRecentlyIndexed =
-                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(5));
+                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(15));
 
                 if (guildRecentlyIndexed)
                 {
@@ -105,7 +105,9 @@ namespace FMBot.Bot.Commands
 
                 var expectedTime = TimeSpan.FromSeconds(8 * users.Count);
                 var indexStartedReply =
-                    $"Indexing stores which .fmbot members are on your server and stores their initial top artist, albums and tracks. Updating these records happens automatically, but you can also use `.fmupdate` to update your own account.\n\n" +
+                    $"Indexing stores which .fmbot members are on your server and stores their initial top artist, albums and tracks. " +
+                    $"Updating these records happens automatically, but you can also use `.fmupdate` to update your own account.\n" +
+                    $"Confused about how indexing has been changed? [Please read this.](https://fmbot.xyz/commands/whoknows/)\n\n" +
                     $"`{users.Count}` new users or users that have never been indexed added to index queue.";
 
                 indexStartedReply += $"\n`{indexedUserCount}` users already indexed on this server.\n \n";

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -149,9 +149,22 @@ namespace FMBot.Bot.Commands
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
 
 
-            if (force != null && (force.ToLower() == "f" || force.ToLower() == "force"))
+            if (force != null && (force.ToLower() == "f" || force.ToLower() == "-f" || force.ToLower() == "full"))
             {
+                this._embed.WithDescription($"<a:loading:748652128502939778> Fully indexing user {userSettings.UserNameLastFM}..." +
+                                            $"\nThis can take a while. Please don't fully update too often, if you have any issues with the normal update feel free to let us know.");
+
+                var message = await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+
                 await this._indexService.IndexUser(userSettings);
+
+                await message.ModifyAsync(m =>
+                {
+                    m.Embed = new EmbedBuilder()
+                        .WithDescription($"✅ {userSettings.UserNameLastFM} has been fully indexed.")
+                        .WithColor(Constants.SuccessColorGreen)
+                        .Build();
+                });
             }
             else
             {
@@ -167,9 +180,6 @@ namespace FMBot.Bot.Commands
                         .WithColor(Constants.SuccessColorGreen)
                         .Build();
                 });
-
-
-                Console.WriteLine("Test");
             }
 
         }

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -15,15 +15,18 @@ namespace FMBot.Bot.Commands
         private readonly GuildService _guildService;
         private readonly UserService _userService;
         private readonly IIndexService _indexService;
+        private readonly IUpdateService _updateService;
         private readonly Logger.Logger _logger;
 
         public IndexCommands(Logger.Logger logger,
             IIndexService indexService,
+            IUpdateService updateService,
             GuildService guildService,
             UserService userService)
         {
             this._logger = logger;
             this._indexService = indexService;
+            this._updateService = updateService;
             this._guildService = guildService;
             this._userService = userService;
             this._embed = new EmbedBuilder()
@@ -31,7 +34,7 @@ namespace FMBot.Bot.Commands
         }
 
         [Command("index", RunMode = RunMode.Async)]
-        [Summary("Indexes top 4000 artists for every user in your server.")]
+        [Summary("Indexes top artists, albums and tracks for every user in your server.")]
         public async Task IndexGuildAsync()
         {
             if (this._guildService.CheckIfDM(this.Context))
@@ -141,14 +144,21 @@ namespace FMBot.Bot.Commands
         [Command("update", RunMode = RunMode.Async)]
         [Summary("Update user.")]
         [LoginRequired]
-        public async Task UpdateUserAsync()
+        public async Task UpdateUserAsync(string force = null)
         {
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
 
-            await this._indexService.UpdateUser(userSettings);
+
+            if (force != null && (force.ToLower() == "f" || force.ToLower() == "force"))
+            {
+                await this._indexService.IndexUser(userSettings);
+            }
+            else
+            {
+                await this._updateService.UpdateUser(userSettings);
+            }
 
             await ReplyAsync("You have been updated");
-
         }
     }
 }

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -158,13 +158,12 @@ namespace FMBot.Bot.Commands
                 this._embed.WithDescription($"<a:loading:748652128502939778> Updating user {userSettings.UserNameLastFM}...");
                 var message = await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
 
-                await this._updateService.UpdateUser(userSettings);
-
+                var scrobblesUsed = await this._updateService.UpdateUser(userSettings);
 
                 await message.ModifyAsync(m =>
                 {
                     m.Embed = new EmbedBuilder()
-                        .WithDescription($"✔️ {userSettings.UserNameLastFM} has been updated.")
+                        .WithDescription($"✅ {userSettings.UserNameLastFM} has been updated based on {scrobblesUsed} new scrobbles.")
                         .WithColor(Constants.SuccessColorGreen)
                         .Build();
                 });

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -2,26 +2,30 @@ using System;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using FMBot.Bot.Attributes;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 
-namespace FMBot.Bot.Commands.LastFM
+namespace FMBot.Bot.Commands
 {
     public class IndexCommands : ModuleBase
     {
         private readonly EmbedBuilder _embed;
         private readonly GuildService _guildService;
+        private readonly UserService _userService;
         private readonly IIndexService _indexService;
         private readonly Logger.Logger _logger;
 
         public IndexCommands(Logger.Logger logger,
             IIndexService indexService,
-            GuildService guildService)
+            GuildService guildService,
+            UserService userService)
         {
             this._logger = logger;
             this._indexService = indexService;
             this._guildService = guildService;
+            this._userService = userService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
         }
@@ -132,6 +136,19 @@ namespace FMBot.Bot.Commands.LastFM
                     "Something went wrong while indexing users. Please let us know as this feature is in beta.");
                 await this._guildService.UpdateGuildIndexTimestampAsync(this.Context.Guild, DateTime.UtcNow);
             }
+        }
+
+        [Command("update", RunMode = RunMode.Async)]
+        [Summary("Update user.")]
+        [LoginRequired]
+        public async Task UpdateUserAsync()
+        {
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+
+            await this._indexService.UpdateUser(userSettings);
+
+            await ReplyAsync("You have been updated");
+
         }
     }
 }

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -501,11 +501,13 @@ namespace FMBot.Bot.Commands.LastFM
                 }
 
                 this._embed.WithDescription(serverUsers);
-                var footer = "";
+
+                var userTitle = await this._userService.GetUserTitleAsync(this.Context);
+                var footer = $"WhoKnows album requested by {userTitle}";
 
                 if (lastIndex < DateTime.UtcNow.AddDays(-3))
                 {
-                    footer += "Missing members? Update with .fmindex";
+                    footer += "\nMissing members? Update with .fmindex";
                 }
 
                 this._embed.WithTitle($"Who knows {albumName} in {this.Context.Guild.Name}");

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -39,11 +39,12 @@ namespace FMBot.Bot.Commands.LastFM
         public AlbumCommands(Logger.Logger logger,
             ILastfmApi lastfmApi,
             IPrefixService prefixService,
-            UserService userService)
+            UserService userService,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._lastfmApi = lastfmApi;
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._prefixService = prefixService;
             this._guildService = new GuildService();
             this._userService = userService;

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -508,11 +508,13 @@ namespace FMBot.Bot.Commands.LastFM
                 }
 
                 this._embed.WithDescription(serverUsers);
-                var footer = "";
+
+                var userTitle = await this._userService.GetUserTitleAsync(this.Context);
+                var footer = $"WhoKnows artist requested by {userTitle}";
 
                 if (lastIndex < DateTime.UtcNow.AddDays(-3))
                 {
-                    footer += "Missing members? Update with .fmindex";
+                    footer += "\nMissing members? Update with .fmindex";
                 }
 
                 if (guild.GuildUsers.Count < 400)

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -10,6 +10,8 @@ using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain;
+using FMBot.Domain.Models;
 using FMBot.LastFM.Domain.Models;
 using FMBot.LastFM.Domain.Types;
 using FMBot.LastFM.Services;
@@ -40,11 +42,12 @@ namespace FMBot.Bot.Commands.LastFM
             ArtistsService artistsService,
             WhoKnowsService whoKnowsService,
             GuildService guildService,
-            UserService userService)
+            UserService userService,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._lastfmApi = lastfmApi;
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._prefixService = prefixService;
             this._artistsService = artistsService;
             this._whoKnowsService = whoKnowsService;

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -36,14 +36,15 @@ namespace FMBot.Bot.Commands.LastFM
             ILastfmApi lastfmApi,
             IChartService chartService,
             GuildService guildService,
-            UserService userService)
+            UserService userService,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._chartService = chartService;
             this._guildService = guildService;
             this._userService = userService;
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -7,10 +7,12 @@ using Discord.Commands;
 using Discord.WebSocket;
 using FMBot.Bot.Attributes;
 using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 using FMBot.LastFM.Services;
 using SkiaSharp;
 
@@ -63,6 +65,7 @@ namespace FMBot.Bot.Commands.LastFM
                 await ReplyAsync($"{prfx}chart '2x2-10x10' '{Constants.CompactTimePeriodList}' \n" +
                                  "Optional extra settings: 'notitles', 'nt', 'skipemptyimages', 's'\n" +
                                  "Options can be used in any order..");
+                this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
 
@@ -78,6 +81,7 @@ namespace FMBot.Bot.Commands.LastFM
                     {
                         var secondString = secondsLeft == 1 ? "second" : "seconds";
                         await ReplyAsync($"Please wait {secondsLeft} {secondString} before generating a chart again.");
+                        this.Context.LogCommandUsed(CommandResponse.Cooldown);
                     }
 
                     return;
@@ -103,6 +107,7 @@ namespace FMBot.Bot.Commands.LastFM
                 {
                     await ReplyAsync(
                         "I'm missing the 'Attach files' permission in this server, so I can't post a chart.");
+                    this.Context.LogCommandUsed(CommandResponse.NoPermission);
                     return;
                 }
             }
@@ -139,6 +144,7 @@ namespace FMBot.Bot.Commands.LastFM
                     }
 
                     await ReplyAsync(reply);
+                    this.Context.LogCommandUsed(CommandResponse.WrongInput);
                     return;
                 }
 
@@ -206,13 +212,11 @@ namespace FMBot.Bot.Commands.LastFM
                     false,
                     this._embed.Build());
 
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
-                this._logger.LogError(e.Message, this.Context.Message.Content, this.Context.User.Username,
-                    this.Context.Guild?.Name, this.Context.Guild?.Id);
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Sorry, but I was unable to generate a FMChart due to an internal error. Make sure you have scrobbles and Last.FM isn't having issues, and try again later.");
             }

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -148,7 +148,7 @@ namespace FMBot.Bot.Commands.LastFM
                     return;
                 }
 
-                chartSettings.Albums = albums;
+                chartSettings.Albums = albums.Content.ToList();
 
                 if (self)
                 {

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -132,7 +132,6 @@ namespace FMBot.Bot.Commands.LastFM
                 var recentScrobbles = recentScrobblesTask.Result;
                 var userInfo = userInfoTask.Result;
 
-
                 if (recentScrobbles?.Any() != true)
                 {
                     this._embed.NoScrobblesFoundErrorResponse(recentScrobbles.Status, this.Context, this._logger);
@@ -705,11 +704,13 @@ namespace FMBot.Bot.Commands.LastFM
                 }
 
                 this._embed.WithDescription(serverUsers);
-                var footer = "";
+
+                var userTitle = await this._userService.GetUserTitleAsync(this.Context);
+                var footer = $"WhoKnows track requested by {userTitle}";
 
                 if (lastIndex < DateTime.UtcNow.AddDays(-3))
                 {
-                    footer += "Missing members? Update with .fmindex";
+                    footer += "\nMissing members? Update with .fmindex";
                 }
 
                 this._embed.WithTitle($"Who knows {trackName} in {this.Context.Guild.Name}");

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -38,13 +38,14 @@ namespace FMBot.Bot.Commands.LastFM
             IPrefixService prefixService,
             ILastfmApi lastfmApi,
             GuildService guildService,
-            UserService userService)
+            UserService userService,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._guildService = guildService;
             this._userService = userService;
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -207,17 +207,6 @@ namespace FMBot.Bot.Commands.LastFM
                         var albumImagesTask =
                             this._lastFmService.GetAlbumImagesAsync(currentTrack.ArtistName, currentTrack.AlbumName);
 
-                        if (!this._guildService.CheckIfDM(this.Context))
-                        {
-                            var perms = await this._guildService.CheckSufficientPermissionsAsync(this.Context);
-                            if (!perms.EmbedLinks)
-                            {
-                                await ReplyAsync(
-                                    "Insufficient permissions, I need to the 'Embed links' permission to show you your scrobbles.");
-                                break;
-                            }
-                        }
-
                         if (userSettings.FmEmbedType == FmEmbedType.embedmini)
                         {
                             fmText += LastFMService.TrackToLinkedString(currentTrack);

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -85,7 +85,7 @@ namespace FMBot.Bot.Commands.LastFM
                 var replyString = $"`{prfx}{fmString}` shows you your last scrobble(s). \n " +
                                   $"This command can also be used on others, for example `{prfx}{fmString} lastfmusername` or `{prfx}{fmString} @discorduser`\n \n" +
 
-                                  "You can set your username and you can change the mode with the `.fmset` command.\n";
+                                  $"You can set your username and you can change the mode with the `{prfx}set` command.\n";
 
                 var differentMode = userSettings.FmEmbedType == FmEmbedType.embedmini ? "embedfull" : "embedmini";
                 replyString += $"`{prfx}set {userSettings.UserNameLastFM} {differentMode}` \n \n" +

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -429,6 +429,8 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
+            _ = this.Context.Channel.TriggerTypingAsync();
+
             var track = await this.SearchTrack(trackValues, userSettings);
             if (track == null)
             {

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -12,6 +12,8 @@ using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Bot.Services.WhoKnows;
+using FMBot.Domain;
 using FMBot.Domain.Models;
 using FMBot.LastFM.Domain.Models;
 using FMBot.LastFM.Domain.Types;
@@ -28,6 +30,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly EmbedFooterBuilder _embedFooter;
         private readonly GuildService _guildService;
         private readonly LastFMService _lastFmService;
+        private readonly WhoKnowsTrackService _whoKnowsTrackService;
         private readonly SpotifyService _spotifyService = new SpotifyService();
         private readonly Logger.Logger _logger;
 
@@ -40,13 +43,15 @@ namespace FMBot.Bot.Commands.LastFM
             ILastfmApi lastfmApi,
             GuildService guildService,
             UserService userService,
-            LastFMService lastFmService)
+            LastFMService lastFmService,
+            WhoKnowsTrackService whoKnowsTrackService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._guildService = guildService;
             this._userService = userService;
             this._lastFmService = lastFmService;
+            this._whoKnowsTrackService = whoKnowsTrackService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();
@@ -286,7 +291,7 @@ namespace FMBot.Bot.Commands.LastFM
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.Bot.Prefix;
 
-            if (user == "help")
+            if (amount == "help")
             {
                 await ReplyAsync($"{prfx}recent 'number of items (max 10)' 'lastfm username/discord user'");
                 this.Context.LogCommandUsed(CommandResponse.Help);
@@ -521,54 +526,6 @@ namespace FMBot.Bot.Commands.LastFM
             this.Context.LogCommandUsed();
         }
 
-        private async Task<ResponseTrack> SearchTrack(string[] trackValues, User userSettings)
-        {
-            string searchValue;
-            if (trackValues.Any())
-            {
-                searchValue = string.Join(" ", trackValues);
-            }
-            else
-            {
-                var track = await this._lastFmService.GetRecentScrobblesAsync(userSettings.UserNameLastFM, 1);
-
-                if (!track.Content.Any())
-                {
-                    this._embed.NoScrobblesFoundErrorResponse(track.Status, this.Context, this._logger);
-                    await this.ReplyAsync("", false, this._embed.Build());
-                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
-                    return null;
-                }
-
-                var trackResult = track.Content.First();
-                searchValue = $"{trackResult.Name} {trackResult.ArtistName}";
-            }
-
-            var result = await this._lastFmService.SearchTrackAsync(searchValue);
-            if (result.Success && result.Content.Any())
-            {
-                var track = result.Content[0];
-
-                var trackInfo = await this._lastFmService.GetTrackInfoAsync(track.Name, track.ArtistName,
-                    userSettings.UserNameLastFM);
-                return trackInfo;
-            }
-            else if (result.Success)
-            {
-                this._embed.WithDescription($"Track could not be found, please check your search values and try again.");
-                await this.ReplyAsync("", false, this._embed.Build());
-                this.Context.LogCommandUsed(CommandResponse.NotFound);
-                return null;
-            }
-            else
-            {
-                this._embed.WithDescription($"Last.fm returned an error: {result.Status}");
-                await this.ReplyAsync("", false, this._embed.Build());
-                this.Context.LogCommandUsed(CommandResponse.Error);
-                return null;
-            }
-        }
-
         [Command("toptracks", RunMode = RunMode.Async)]
         [Summary("Displays top tracks.")]
         [Alias("tt", "tl", "tracklist", "tracks", "trackslist")]
@@ -589,8 +546,7 @@ namespace FMBot.Bot.Commands.LastFM
                     $"`{prfx}toptracks alltime @john 11`");
 
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
 
@@ -675,6 +631,107 @@ namespace FMBot.Bot.Commands.LastFM
             }
         }
 
+        [Command("whoknowstrack", RunMode = RunMode.Async)]
+        [Summary("Shows what other users listen to the same artist in your server")]
+        [Alias("wt", "wkt", "wktr", "wtr", "wktrack", "wk track", "whoknows track")]
+        [LoginRequired]
+        public async Task WhoKnowsAsync(params string[] trackValues)
+        {
+            if (this._guildService.CheckIfDM(this.Context))
+            {
+                await ReplyAsync("This command is not supported in DMs.");
+                this.Context.LogCommandUsed(CommandResponse.NotSupportedInDm);
+                return;
+            }
+
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.Bot.Prefix;
+
+            var lastIndex = await this._guildService.GetGuildIndexTimestampAsync(this.Context.Guild);
+
+            if (lastIndex == null)
+            {
+                await ReplyAsync("This server hasn't been indexed yet.\n" +
+                                 $"Please run `{prfx}index` to index this server.");
+                this.Context.LogCommandUsed(CommandResponse.IndexRequired);
+                return;
+            }
+            if (lastIndex < DateTime.UtcNow.AddDays(-50))
+            {
+                await ReplyAsync("Server index data is out of date, it was last updated over 50 days ago.\n" +
+                                 $"Please run `{prfx}index` to re-index this server.");
+                this.Context.LogCommandUsed(CommandResponse.IndexRequired);
+                return;
+            }
+
+            var guildTask = this._guildService.GetGuildAsync(this.Context.Guild.Id);
+
+            if (trackValues.Any() && trackValues.First() == "help")
+            {
+                await ReplyAsync(
+                    $"Usage: `{prfx}whoknowstrack 'artist and track name'`\n" +
+                    "If you don't enter any track name, it will get the info from the track you're currently listening to.");
+                this.Context.LogCommandUsed(CommandResponse.Help);
+                return;
+            }
+
+            _ = this.Context.Channel.TriggerTypingAsync();
+
+            var track = await this.SearchTrack(trackValues, userSettings);
+            if (track == null)
+            {
+                return;
+            }
+
+            var trackName = $"{track.Artist.Name} - {track.Name}";
+
+            try
+            {
+                var guild = await guildTask;
+                var users = guild.GuildUsers.Select(s => s.User).ToList();
+
+                var usersWithArtist = await this._whoKnowsTrackService.GetIndexedUsersForTrack(this.Context, users, track.Artist.Name, track.Name);
+
+                if (track.Userplaycount != 0)
+                {
+                    var guildUser = await this.Context.Guild.GetUserAsync(this.Context.User.Id);
+                    usersWithArtist = WhoKnowsService.AddOrReplaceUserToIndexList(usersWithArtist, userSettings, guildUser, trackName, track.Userplaycount);
+                }
+
+                var serverUsers = WhoKnowsService.WhoKnowsListToString(usersWithArtist);
+                if (usersWithArtist.Count == 0)
+                {
+                    serverUsers = "Nobody in this server (not even you) has listened to this track.";
+                }
+
+                this._embed.WithDescription(serverUsers);
+                var footer = "";
+
+                if (lastIndex < DateTime.UtcNow.AddDays(-3))
+                {
+                    footer += "Missing members? Update with .fmindex";
+                }
+
+                this._embed.WithTitle($"Who knows {trackName} in {this.Context.Guild.Name}");
+
+                if (Uri.IsWellFormedUriString(track.Url, UriKind.Absolute))
+                {
+                    this._embed.WithUrl(track.Url);
+                }
+
+                this._embedFooter.WithText(footer);
+                this._embed.WithFooter(this._embedFooter);
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+                this.Context.LogCommandUsed();
+            }
+            catch (Exception e)
+            {
+                this.Context.LogCommandException(e);
+                await ReplyAsync("Something went wrong while using whoknows track. Please let us know as this feature is in beta.");
+            }
+        }
+
         private async Task<string> FindUser(string user)
         {
             if (await this._lastFmService.LastFMUserExistsAsync(user))
@@ -712,6 +769,54 @@ namespace FMBot.Bot.Commands.LastFM
             }
 
             return null;
+        }
+
+        private async Task<ResponseTrack> SearchTrack(string[] trackValues, User userSettings)
+        {
+            string searchValue;
+            if (trackValues.Any())
+            {
+                searchValue = string.Join(" ", trackValues);
+            }
+            else
+            {
+                var track = await this._lastFmService.GetRecentScrobblesAsync(userSettings.UserNameLastFM, 1);
+
+                if (!track.Content.Any())
+                {
+                    this._embed.NoScrobblesFoundErrorResponse(track.Status, this.Context, this._logger);
+                    await this.ReplyAsync("", false, this._embed.Build());
+                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
+                    return null;
+                }
+
+                var trackResult = track.Content.First();
+                searchValue = $"{trackResult.Name} {trackResult.ArtistName}";
+            }
+
+            var result = await this._lastFmService.SearchTrackAsync(searchValue);
+            if (result.Success && result.Content.Any())
+            {
+                var track = result.Content[0];
+
+                var trackInfo = await this._lastFmService.GetTrackInfoAsync(track.Name, track.ArtistName,
+                    userSettings.UserNameLastFM);
+                return trackInfo;
+            }
+            else if (result.Success)
+            {
+                this._embed.WithDescription($"Track could not be found, please check your search values and try again.");
+                await this.ReplyAsync("", false, this._embed.Build());
+                this.Context.LogCommandUsed(CommandResponse.NotFound);
+                return null;
+            }
+            else
+            {
+                this._embed.WithDescription($"Last.fm returned an error: {result.Status}");
+                await this.ReplyAsync("", false, this._embed.Build());
+                this.Context.LogCommandUsed(CommandResponse.Error);
+                return null;
+            }
         }
     }
 }

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -418,9 +418,16 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (trackValues.Any() && trackValues.First() == "help")
             {
-                await ReplyAsync(
-                    $"Usage: `{prfx}track 'artist and track name'`\n" +
-                    "If you don't enter any track name, it will get the info from the track you're currently listening to.");
+                this._embed.WithTitle($"{prfx}track");
+                this._embed.WithDescription($"Shows track info about the track you're currently listening to or searching for.");
+
+                this._embed.AddField("Examples",
+                    $"`{prfx}tr` \n" +
+                    $"`{prfx}track` \n" +
+                    $"`{prfx}track Depeche Mode Enjoy The Silence` \n" +
+                    $"`{prfx}track Crystal Waters | Gypsy Woman (She's Homeless) - Radio Edit`");
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
                 this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
@@ -500,9 +507,16 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (trackValues.Any() && trackValues.First() == "help")
             {
-                await ReplyAsync(
-                    $"Usage: `{prfx}trackplays 'artist and track name'`\n" +
-                    "If you don't enter any track name, it will get the info from the track you're currently listening to.");
+                this._embed.WithTitle($"{prfx}trackplays");
+                this._embed.WithDescription($"Shows your total plays from the track you're currently listening to or searching for.");
+
+                this._embed.AddField("Examples",
+                    $"`{prfx}tp` \n" +
+                    $"`{prfx}trackplays` \n" +
+                    $"`{prfx}trackplays Mac DeMarco Here Comes The Cowboy` \n" +
+                    $"`{prfx}trackplays Cocteau Twins | Heaven or Las Vegas`");
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
                 this.Context.LogCommandUsed(CommandResponse.Help);
                 return;
             }
@@ -646,6 +660,22 @@ namespace FMBot.Bot.Commands.LastFM
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.Bot.Prefix;
 
+            if (trackValues.Any() && trackValues.First() == "help")
+            {
+                this._embed.WithTitle($"{prfx}whoknowstrack");
+                this._embed.WithDescription($"Shows what members in your server listened to the track you're currently listening to or searching for.");
+
+                this._embed.AddField("Examples",
+                    $"`{prfx}wt` \n" +
+                    $"`{prfx}whoknowstrack` \n" +
+                    $"`{prfx}whoknowstrack Hothouse Flowers Don't Go` \n" +
+                    $"`{prfx}whoknowstrack Natasha Bedingfield | Unwritten`");
+
+                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+                this.Context.LogCommandUsed(CommandResponse.Help);
+                return;
+            }
+
             var lastIndex = await this._guildService.GetGuildIndexTimestampAsync(this.Context.Guild);
 
             if (lastIndex == null)
@@ -778,6 +808,13 @@ namespace FMBot.Bot.Commands.LastFM
             if (trackValues.Any())
             {
                 searchValue = string.Join(" ", trackValues);
+
+                if (searchValue.Contains(" | "))
+                {
+                    var trackInfo = await this._lastFmService.GetTrackInfoAsync(searchValue.Split(" | ")[1], searchValue.Split(" | ")[0],
+                        userSettings.UserNameLastFM);
+                    return trackInfo;
+                }
             }
             else
             {

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -31,7 +31,8 @@ namespace FMBot.Bot.Commands.LastFM
             Logger.Logger logger,
             IPrefixService prefixService,
             ILastfmApi lastfmApi,
-            GuildService guildService)
+            GuildService guildService,
+            LastFMService lastFmService)
         {
             this._timer = timer;
             this._logger = logger;
@@ -39,7 +40,7 @@ namespace FMBot.Bot.Commands.LastFM
             this._guildService = guildService;
             this._friendsService = new FriendsService();
             this._userService = new UserService();
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -109,7 +109,7 @@ namespace FMBot.Bot.Commands.LastFM
                 var userInfo = await this._lastFmService.GetUserInfoAsync(lastFMUserName);
 
                 var userImages = userInfo.Content.Avatar;
-                var userAvatar = userImages?.Large.AbsoluteUri;
+                var userAvatar = userImages?.Large?.AbsoluteUri;
 
                 if (!string.IsNullOrWhiteSpace(userAvatar))
                 {

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -153,8 +153,7 @@ namespace FMBot.Bot.Commands.LastFM
 
 
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-                this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                    this.Context.Message.Content);
+                this.Context.LogCommandUsed();
             }
             catch (Exception e)
             {
@@ -174,6 +173,7 @@ namespace FMBot.Bot.Commands.LastFM
         {
             var prfx = ConfigData.Data.Bot.Prefix;
 
+            var existingUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             if (lastFMUserName == null || lastFMUserName == "help")
             {
                 var replyString = ".fmset is the command you use to set your last.fm username in the bot, so it knows who you are on the last.fm website. \n" +
@@ -181,12 +181,11 @@ namespace FMBot.Bot.Commands.LastFM
                                   "Sets your username, mode and playcount for the `.fm` command:\n \n" +
                                   $"`{prfx}set 'Last.FM Username' 'embedmini/embedfull/textmini/textfull' 'artist/album/track'` \n \n";
 
-                var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
-                if (userSettings?.UserNameLastFM != null)
+                if (existingUserSettings?.UserNameLastFM != null)
                 {
-                    var differentMode = userSettings.FmEmbedType == FmEmbedType.embedmini ? "embedfull" : "embedmini";
+                    var differentMode = existingUserSettings.FmEmbedType == FmEmbedType.embedmini ? "embedfull" : "embedmini";
                     replyString += "Example of picking a different mode: \n" +
-                                   $"`{prfx}set {userSettings.UserNameLastFM} {differentMode} album`";
+                                   $"`{prfx}set {existingUserSettings.UserNameLastFM} {differentMode} album`";
                 }
                 else
                 {
@@ -219,19 +218,19 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var newUserSettings = new User
+            var userSettingsToAdd = new User
             {
                 UserNameLastFM = lastFMUserName
             };
 
-            newUserSettings = this._userService.SetSettings(newUserSettings, otherSettings);
+            userSettingsToAdd = this._userService.SetSettings(userSettingsToAdd, otherSettings);
 
-            this._userService.SetLastFM(this.Context.User, newUserSettings);
+            this._userService.SetLastFM(this.Context.User, userSettingsToAdd);
 
-            var setReply = $"Your Last.FM name has been set to '{lastFMUserName}' and your .fm mode to '{newUserSettings.FmEmbedType}'";
-            if (newUserSettings.FmCountType != null)
+            var setReply = $"Your Last.FM name has been set to '{lastFMUserName}' and your .fm mode to '{userSettingsToAdd.FmEmbedType}'";
+            if (userSettingsToAdd.FmCountType != null)
             {
-                setReply += $" with the '{newUserSettings.FmCountType.ToString().ToLower()}' playcount.";
+                setReply += $" with the '{userSettingsToAdd.FmCountType.ToString().ToLower()}' playcount.";
             }
 
             if (otherSettings.Length < 1)
@@ -243,12 +242,16 @@ namespace FMBot.Bot.Commands.LastFM
 
             this.Context.LogCommandUsed();
 
-            var freshUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
-            await this._indexService.IndexUser(freshUserSettings);
+            var newUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            if (existingUserSettings == null ||
+                existingUserSettings.UserNameLastFM.ToLower() != newUserSettings.UserNameLastFM.ToLower())
+            {
+                await this._indexService.IndexUser(newUserSettings);
+            }
 
             if (!this._guildService.CheckIfDM(this.Context))
             {
-                await this._indexService.AddUserToGuild(Context.Guild, freshUserSettings);
+                await this._indexService.AddUserToGuild(Context.Guild, newUserSettings);
 
                 var perms = await this._guildService.CheckSufficientPermissionsAsync(this.Context);
                 if (!perms.EmbedLinks || !perms.AttachFiles)

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -47,7 +47,7 @@ namespace FMBot.Bot.Commands.LastFM
             this._friendsService = new FriendsService();
             this._userService = new UserService();
             this._lastFmService = lastFmService;
-            _indexService = indexService;
+            this._indexService = indexService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
             this._embedAuthor = new EmbedAuthorBuilder();

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -6,6 +6,7 @@ using FMBot.Bot.Configurations;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain;
 using FMBot.LastFM.Services;
 using FMBot.Persistence.Domain.Models;
 
@@ -140,6 +141,12 @@ namespace FMBot.Bot.Commands.LastFM
                 this._embed.WithThumbnailUrl(selfUser.GetAvatarUrl());
                 this._embed.AddField("Featured:", this._timer.GetTrackString());
 
+                if (PublicProperties.IssuesAtLastFM)
+                {
+                    this._embed.AddField("Note:", "⚠️ [Last.fm](https://twitter.com/lastfmstatus) is currently experiencing issues");
+                }
+
+
                 await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
                 this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
                     this.Context.Message.Content);
@@ -270,9 +277,9 @@ namespace FMBot.Bot.Commands.LastFM
                 else
                 {
                 */
-                
 
-                
+
+
 
                 this._embedAuthor.WithIconUrl(this.Context.User.GetAvatarUrl());
                 this._embedAuthor.WithName(this.Context.User.ToString());

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -176,7 +176,7 @@ namespace FMBot.Bot.Commands.LastFM
             var existingUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             if (lastFMUserName == null || lastFMUserName == "help")
             {
-                var replyString = ".fmset is the command you use to set your last.fm username in the bot, so it knows who you are on the last.fm website. \n" +
+                var replyString = $"{prfx}set is the command you use to set your last.fm username in the bot, so it knows who you are on the last.fm website. \n" +
                                   "Don't have a last.fm account yet? Register here: https://www.last.fm/join \n \n" +
                                   "Sets your username, mode and playcount for the `.fm` command:\n \n" +
                                   $"`{prfx}set 'Last.FM Username' 'embedmini/embedfull/textmini/textfull' 'artist/album/track'` \n \n";

--- a/src/FMBot.Bot/Commands/SpotifyCommands.cs
+++ b/src/FMBot.Bot/Commands/SpotifyCommands.cs
@@ -25,12 +25,16 @@ namespace FMBot.Bot.Commands
 
         private readonly IPrefixService _prefixService;
 
-        public SpotifyCommands(Logger.Logger logger, IPrefixService prefixService, ILastfmApi lastfmApi)
+        public SpotifyCommands(
+            Logger.Logger logger,
+            IPrefixService prefixService,
+            ILastfmApi lastfmApi,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._userService = new UserService();
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
         }

--- a/src/FMBot.Bot/Commands/SpotifyCommands.cs
+++ b/src/FMBot.Bot/Commands/SpotifyCommands.cs
@@ -9,6 +9,7 @@ using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain.Models;
 using FMBot.LastFM.Services;
 
 namespace FMBot.Bot.Commands
@@ -91,17 +92,17 @@ namespace FMBot.Bot.Commands
                     }
 
                     await ReplyAsync(reply);
-                    this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                        this.Context.Message.Content);
+                    this.Context.LogCommandUsed();
                 }
                 else
                 {
                     await ReplyAsync("No results have been found for this track. Querystring: `" + querystring.FilterOutMentions() + "`");
+                    this.Context.LogCommandUsed(CommandResponse.NotFound);
                 }
             }
             catch (Exception e)
             {
-                this._logger.LogException(this.Context.Message.Content, e);
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Unable to show Last.FM info via Spotify due to an internal error. " +
                     "Try setting a Last.FM name with the 'fmset' command, scrobbling something, and then use the command again.");

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -11,6 +11,7 @@ using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain;
 using static FMBot.Bot.FMBotUtil;
 
 namespace FMBot.Bot.Commands

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -169,14 +169,14 @@ namespace FMBot.Bot.Commands
             this._embed.AddField($"Main command `{prefix}{mainCommand}`",
                 "Displays last scrobbles, and looks different depending on the mode you've set.");
 
-            this._embed.AddField("Setting up: `.fmset lastfmusername`",
+            this._embed.AddField($"Setting up: `{prefix}set lastfmusername`",
                 $"For more settings, please use `{prefix}set help`.");
 
             if (customPrefix)
             {
                 this._embed.AddField("Custom prefix:",
                     $"This server has the `{prefix}` prefix.\n" +
-                    $"Note that the documentation has the `.fm` prefix everywhere.");
+                    $"Note that the documentation has the `.fm` prefix everywhere, so you'll have to replace `.fm` with `{prefix}`.");
             }
 
             this._embed.AddField("For more commands and info, please read the documentation here:",

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -63,6 +63,7 @@ namespace FMBot.Bot.Commands
             }
 
             await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+            this.Context.LogCommandUsed();
         }
 
         [Command("info", RunMode = RunMode.Async)]
@@ -98,6 +99,7 @@ namespace FMBot.Bot.Commands
             }
 
             await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+            this.Context.LogCommandUsed();
         }
 
         [Command("status", RunMode = RunMode.Async)]
@@ -140,6 +142,7 @@ namespace FMBot.Bot.Commands
             this._embed.WithDescription(description);
 
             await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+            this.Context.LogCommandUsed();
         }
 
         [Command("help", RunMode = RunMode.Async)]
@@ -187,6 +190,7 @@ namespace FMBot.Bot.Commands
             }
 
             await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
+            this.Context.LogCommandUsed();
         }
 
 
@@ -244,6 +248,7 @@ namespace FMBot.Bot.Commands
             {
                 await this.Context.Channel.SendMessageAsync("Check your DMs!");
             }
+            this.Context.LogCommandUsed();
         }
 
         private static bool IsBotSelfHosted(ulong botId)

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -77,7 +77,6 @@ namespace FMBot.Bot.Commands
 
                     var name = await this._userService.GetNameAsync(this.Context);
 
-
                     var reply = $"{name} searched for: `{querystring}`";
 
                     var user = await this.Context.Guild.GetUserAsync(this.Context.User.Id);
@@ -99,18 +98,17 @@ namespace FMBot.Bot.Commands
 
                     await ReplyAsync(reply.FilterOutMentions());
 
-                    this._logger.LogCommandUsed(this.Context.Guild?.Id, this.Context.Channel.Id, this.Context.User.Id,
-                        this.Context.Message.Content);
+                    this.Context.LogCommandUsed();
                 }
                 catch (Exception e)
                 {
-                    this._logger.LogException(this.Context.Message.Content, e);
+                    this.Context.LogCommandException(e);
                     await ReplyAsync("No results have been found for this query.");
                 }
             }
             catch (Exception e)
             {
-                this._logger.LogException(this.Context.Message.Content, e);
+                this.Context.LogCommandException(e);
                 await ReplyAsync(
                     "Unable to show Last.FM info via YouTube due to an internal error. Try setting a Last.FM name with the 'fmset' command, scrobbling something, and then use the command again.");
             }

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -87,6 +87,7 @@ namespace FMBot.Bot.Commands
                     else
                     {
                         reply += $"\n<https://www.youtube.com/watch?v={youtubeResult.Id.VideoId}>" +
+                                 $"\n`{youtubeResult.Snippet.Title}`" +
                                  $"\n*Embed disabled because user that requested link is not allowed to embed links.*";
                     }
 

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -77,8 +77,19 @@ namespace FMBot.Bot.Commands
 
                     var name = await this._userService.GetNameAsync(this.Context);
 
-                    var reply = $"{name} searched for: `{querystring}`" +
-                                $"\nhttps://www.youtube.com/watch?v={youtubeResult.Id.VideoId}";
+
+                    var reply = $"{name} searched for: `{querystring}`";
+
+                    var user = await this.Context.Guild.GetUserAsync(this.Context.User.Id);
+                    if (user.GuildPermissions.EmbedLinks)
+                    {
+                        reply += $"\nhttps://www.youtube.com/watch?v={youtubeResult.Id.VideoId}";
+                    }
+                    else
+                    {
+                        reply += $"\n<https://www.youtube.com/watch?v={youtubeResult.Id.VideoId}>" +
+                                 $"\n*Embed disabled because user that requested link is not allowed to embed links.*";
+                    }
 
                     var rnd = new Random();
                     if (rnd.Next(0, 5) == 1 && searchValues.Length < 1)

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -24,12 +24,16 @@ namespace FMBot.Bot.Commands
 
         private readonly IPrefixService _prefixService;
 
-        public YoutubeCommands(Logger.Logger logger, IPrefixService prefixService, ILastfmApi lastfmApi)
+        public YoutubeCommands(
+            Logger.Logger logger,
+            IPrefixService prefixService,
+            ILastfmApi lastfmApi,
+            LastFMService lastFmService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
             this._userService = new UserService();
-            this._lastFmService = new LastFMService(lastfmApi);
+            this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
         }

--- a/src/FMBot.Bot/Configurations/ConfigData.cs
+++ b/src/FMBot.Bot/Configurations/ConfigData.cs
@@ -41,7 +41,10 @@ namespace FMBot.Bot.Configurations
                     }, 
                     BotLists = new BotListConfig(),
                     Discord = new DiscordConfig(),
-                    LastFm = new LastFmConfig(),
+                    LastFm = new LastFmConfig
+                    {
+                        UserUpdateFrequencyInHours = 24
+                    },
                     Genius = new GeniusConfig(),
                     Spotify = new SpotifyConfig(),
                     Google = new GoogleConfig()

--- a/src/FMBot.Bot/Extensions/LogExtensions.cs
+++ b/src/FMBot.Bot/Extensions/LogExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using Discord.Commands;
+using FMBot.Domain.Models;
+using Serilog;
+
+namespace FMBot.Bot.Extensions
+{
+    public static class LogExtensions
+    {
+        public static void LogCommandUsed(this ICommandContext context, CommandResponse commandResponse = CommandResponse.Ok)
+        {
+            Log.Information("CommandUsed: {userName} / {UserId} | {guildName} / {guildId} | {commandResponse} | {messageContent}",
+                context.User?.Username, context.User?.Id, context.Guild?.Name, context.Guild?.Id, commandResponse, context.Message.Content);
+        }
+
+        public static void LogCommandException(this ICommandContext context, Exception exception)
+        {
+            Log.Error(exception, "CommandUsed: {userName} / {UserId} | {guildName} / {guildId} | {commandResponse} | {messageContent}",
+                context.User?.Username, context.User?.Id, context.Guild?.Name, context.Guild?.Id, CommandResponse.Error, context.Message.Content);
+        }
+    }
+}

--- a/src/FMBot.Bot/Extensions/LogExtensions.cs
+++ b/src/FMBot.Bot/Extensions/LogExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Discord.Commands;
 using FMBot.Domain.Models;
+using FMBot.LastFM.Domain.Enums;
 using Serilog;
 
 namespace FMBot.Bot.Extensions
@@ -17,6 +18,12 @@ namespace FMBot.Bot.Extensions
         {
             Log.Error(exception, "CommandUsed: {userName} / {UserId} | {guildName} / {guildId} | {commandResponse} | {messageContent}",
                 context.User?.Username, context.User?.Id, context.Guild?.Name, context.Guild?.Id, CommandResponse.Error, context.Message.Content);
+        }
+
+        public static void LogCommandWithLastFmError(this ICommandContext context, ResponseStatus? responseStatus)
+        {
+            Log.Error("CommandUsed: {userName} / {UserId} | {guildName} / {guildId} | {commandResponse} | {messageContent} | Last.fm error: {responseStatus}",
+                context.User?.Username, context.User?.Id, context.Guild?.Name, context.Guild?.Id, CommandResponse.LastFmError, context.Message.Content, responseStatus);
         }
     }
 }

--- a/src/FMBot.Bot/Extensions/ObservableExtensions.cs
+++ b/src/FMBot.Bot/Extensions/ObservableExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using Serilog;
 
 namespace FMBot.Bot.Extensions
 {
@@ -19,11 +20,11 @@ namespace FMBot.Bot.Extensions
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine("Error occured in subscription OnNext");
+                        Log.Error(ex, "Error occured in subscription OnNext");
                     }
                 }, ex =>
                 {
-                    Console.WriteLine("Error occured in subscription OnNext");
+                    Log.Error(ex, "Error occured in subscription OnNext");
                 });
         }
     }

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -31,8 +31,8 @@
     <PackageReference Include="Google.Apis" Version="1.48.0" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.47.0.2008" />
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.2" />
     <PackageReference Include="Npgsql" Version="4.1.4" />

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -52,6 +52,7 @@
     <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\FMBot.Domain\FMBot.Domain.csproj" />
     <ProjectReference Include="..\FMBot.LastFM.Domain\FMBot.LastFM.Domain.csproj" />
     <ProjectReference Include="..\FMBot.Persistence.Domain\FMBot.Persistence.Domain.csproj" />
     <ProjectReference Include="..\FMBot.Persistence.EntityFrameWork\FMBot.Persistence.EntityFrameWork.csproj" />

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Google.Apis" Version="1.48.0" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.47.0.2008" />
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.8.20407.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.2" />

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -31,10 +31,9 @@
     <PackageReference Include="Google.Apis" Version="1.48.0" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.47.0.2008" />
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.8.20407.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
-    <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.2" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.3" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
     <PackageReference Include="PostgreSQLCopyHelper" Version="2.6.3" />
     <PackageReference Include="prometheus-net" Version="3.6.0" />

--- a/src/FMBot.Bot/FMBotUtil.cs
+++ b/src/FMBot.Bot/FMBotUtil.cs
@@ -36,6 +36,8 @@ namespace FMBot.Bot
                 new CensoredAlbum("Last Days Of Humanity", "In Advanced Haemorrhaging Conditions"),
                 new CensoredAlbum("Last Days Of Humanity", "Extreme Experience Of Inhuman Motivations"),
                 new CensoredAlbum("Cannibal Corpse", "Tomb of the Mutilated"),
+                new CensoredAlbum("Cannibal Corpse", "Tomb of the Mutilated"),
+                new CensoredAlbum("Cannibal Corpse", "Tomb of the Mutilated"),
                 new CensoredAlbum("Regurgitate", "Carnivorous Erection")
             };
 

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -10,6 +10,7 @@ using FMBot.Bot.Configurations;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
+using FMBot.Domain;
 
 namespace FMBot.Bot.Handlers
 {

--- a/src/FMBot.Bot/Interfaces/IIndexService.cs
+++ b/src/FMBot.Bot/Interfaces/IIndexService.cs
@@ -11,6 +11,8 @@ namespace FMBot.Bot.Interfaces
 
         Task IndexUser(User user);
 
+        Task AddUserToGuild(IGuild guild, User user);
+
         Task StoreGuildUsers(IGuild guild, IReadOnlyCollection<IGuildUser> guildUsers);
 
         Task<IReadOnlyList<User>> GetUsersToIndex(IReadOnlyCollection<IGuildUser> guildUsers);

--- a/src/FMBot.Bot/Interfaces/IIndexService.cs
+++ b/src/FMBot.Bot/Interfaces/IIndexService.cs
@@ -9,7 +9,7 @@ namespace FMBot.Bot.Interfaces
     {
         void IndexGuild(IReadOnlyList<User> users);
 
-        Task UpdateUser(User user);
+        Task IndexUser(User user);
 
         Task StoreGuildUsers(IGuild guild, IReadOnlyCollection<IGuildUser> guildUsers);
 

--- a/src/FMBot.Bot/Interfaces/IIndexService.cs
+++ b/src/FMBot.Bot/Interfaces/IIndexService.cs
@@ -9,6 +9,8 @@ namespace FMBot.Bot.Interfaces
     {
         void IndexGuild(IReadOnlyList<User> users);
 
+        Task UpdateUser(User user);
+
         Task StoreGuildUsers(IGuild guild, IReadOnlyCollection<IGuildUser> guildUsers);
 
         Task<IReadOnlyList<User>> GetUsersToIndex(IReadOnlyCollection<IGuildUser> guildUsers);

--- a/src/FMBot.Bot/Interfaces/IUpdateService.cs
+++ b/src/FMBot.Bot/Interfaces/IUpdateService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using FMBot.Persistence.Domain.Models;
+
+namespace FMBot.Bot.Interfaces
+{
+    public interface IUpdateService
+    {
+        Task UpdateUser(User user);
+    }
+}

--- a/src/FMBot.Bot/Interfaces/IUpdateService.cs
+++ b/src/FMBot.Bot/Interfaces/IUpdateService.cs
@@ -5,6 +5,6 @@ namespace FMBot.Bot.Interfaces
 {
     public interface IUpdateService
     {
-        Task UpdateUser(User user);
+        Task<int> UpdateUser(User user);
     }
 }

--- a/src/FMBot.Bot/Interfaces/IUpdateService.cs
+++ b/src/FMBot.Bot/Interfaces/IUpdateService.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FMBot.Persistence.Domain.Models;
 
@@ -5,6 +7,10 @@ namespace FMBot.Bot.Interfaces
 {
     public interface IUpdateService
     {
+        void AddUsersToUpdateQueue(IReadOnlyList<User> users);
+
         Task<int> UpdateUser(User user);
+
+        Task<IReadOnlyList<User>> GetOutdatedUsers(DateTime timeLastUpdated);
     }
 }

--- a/src/FMBot.Bot/Interfaces/IUserUpdateQueue.cs
+++ b/src/FMBot.Bot/Interfaces/IUserUpdateQueue.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using FMBot.Persistence.Domain.Models;
+
+namespace FMBot.Bot.Interfaces
+{
+    public interface IUserUpdateQueue
+    {
+        IObservable<User> UsersToUpdate { get; }
+
+        void Publish(IReadOnlyList<User> users);
+    }
+}

--- a/src/FMBot.Bot/Models/ChartModels.cs
+++ b/src/FMBot.Bot/Models/ChartModels.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Drawing;
 using Discord;
 using IF.Lastfm.Core.Api.Enums;
-using IF.Lastfm.Core.Api.Helpers;
 using IF.Lastfm.Core.Objects;
 using SkiaSharp;
 using Color = System.Drawing.Color;
@@ -21,7 +19,7 @@ namespace FMBot.Bot.Models
             this.SkipArtistsWithoutImage = false;
         }
 
-        public PageResponse<LastAlbum> Albums { get; set; }
+        public List<LastAlbum> Albums { get; set; }
 
         public int Height { get; set; }
 

--- a/src/FMBot.Bot/Models/ConfigModel.cs
+++ b/src/FMBot.Bot/Models/ConfigModel.cs
@@ -61,6 +61,8 @@ namespace FMBot.Bot.Models
         public string Key { get; set; }
 
         public string Secret { get; set; }
+
+        public int? UserUpdateFrequencyInHours { get; set; }
     }
 
     public class SpotifyConfig

--- a/src/FMBot.Bot/Models/TasteModels.cs
+++ b/src/FMBot.Bot/Models/TasteModels.cs
@@ -1,3 +1,4 @@
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.Bot.Models

--- a/src/FMBot.Bot/Models/UserUpdateQueue.cs
+++ b/src/FMBot.Bot/Models/UserUpdateQueue.cs
@@ -7,17 +7,17 @@ using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.Bot.Models
 {
-    public class UserIndexQueue : IUserIndexQueue
+    public class UserUpdateQueue : IUserUpdateQueue
     {
         private readonly Subject<IReadOnlyList<User>> _subject;
 
-        public UserIndexQueue()
+        public UserUpdateQueue()
         {
             this._subject = new Subject<IReadOnlyList<User>>();
-            this.UsersToIndex = this._subject.SelectMany(q => q);
+            this.UsersToUpdate = this._subject.SelectMany(q => q);
         }
 
-        public IObservable<User> UsersToIndex { get; }
+        public IObservable<User> UsersToUpdate { get; }
 
         public void Publish(IReadOnlyList<User> users)
         {

--- a/src/FMBot.Bot/Models/WhoKnowsObjectWithUser.cs
+++ b/src/FMBot.Bot/Models/WhoKnowsObjectWithUser.cs
@@ -1,8 +1,8 @@
 namespace FMBot.Bot.Models
 {
-    public class ArtistWithUser
+    public class WhoKnowsObjectWithUser
     {
-        public string ArtistName { get; set; }
+        public string Name { get; set; }
 
         public int Playcount { get; set; }
 

--- a/src/FMBot.Bot/Properties/launchSettings.json
+++ b/src/FMBot.Bot/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "FMBot.Bot": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "sqlDebugging": true
     },
     "Docker": {
       "commandName": "Docker"

--- a/src/FMBot.Bot/Resources/Constants.cs
+++ b/src/FMBot.Bot/Resources/Constants.cs
@@ -28,6 +28,8 @@ namespace FMBot.Bot.Resources
 
         /// <summary>The Discord color for a warning embed.</summary>
         public static Color WarningColorOrange = new Color(255, 174, 66);
+
+        public static Color SuccessColorGreen = new Color(96, 2, 238);
     }
 }
 

--- a/src/FMBot.Bot/Resources/Constants.cs
+++ b/src/FMBot.Bot/Resources/Constants.cs
@@ -29,7 +29,7 @@ namespace FMBot.Bot.Resources
         /// <summary>The Discord color for a warning embed.</summary>
         public static Color WarningColorOrange = new Color(255, 174, 66);
 
-        public static Color SuccessColorGreen = new Color(96, 2, 238);
+        public static Color SuccessColorGreen = new Color(50, 205, 50);
     }
 }
 

--- a/src/FMBot.Bot/Resources/Constants.cs
+++ b/src/FMBot.Bot/Resources/Constants.cs
@@ -21,8 +21,6 @@ namespace FMBot.Bot.Resources
 
         public const string ExpandedTimePeriodList = "'weekly', 'monthly', 'quarterly', 'half', 'yearly', or 'alltime'";
 
-        public static TimeSpan GuildIndexCooldown = TimeSpan.FromDays(2);
-
         /// <summary>Amount of users to index. Should always end with 000</summary>
         public const int ArtistsToIndex = 4000;
 

--- a/src/FMBot.Bot/Services/ArtistsService.cs
+++ b/src/FMBot.Bot/Services/ArtistsService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Models;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 using IF.Lastfm.Core.Api.Helpers;
 using IF.Lastfm.Core.Objects;

--- a/src/FMBot.Bot/Services/ChartService.cs
+++ b/src/FMBot.Bot/Services/ChartService.cs
@@ -8,6 +8,8 @@ using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
+using FMBot.Domain;
+using FMBot.LastFM.Services;
 using IF.Lastfm.Core.Objects;
 using Microsoft.EntityFrameworkCore.Internal;
 using SkiaSharp;

--- a/src/FMBot.Bot/Services/GeniusService.cs
+++ b/src/FMBot.Bot/Services/GeniusService.cs
@@ -1,10 +1,8 @@
+using System.Linq;
 using System.Threading.Tasks;
 using FMBot.Bot.Configurations;
-using FMBot.Bot.Models;
 using Genius;
 using Genius.Models;
-using Microsoft.EntityFrameworkCore.Internal;
-using Newtonsoft.Json.Linq;
 
 namespace FMBot.Bot.Services
 {

--- a/src/FMBot.Bot/Services/GuildService.cs
+++ b/src/FMBot.Bot/Services/GuildService.cs
@@ -8,6 +8,7 @@ using Discord.Commands;
 using Discord.WebSocket;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Models;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;

--- a/src/FMBot.Bot/Services/IndexService.cs
+++ b/src/FMBot.Bot/Services/IndexService.cs
@@ -20,18 +20,18 @@ namespace FMBot.Bot.Services
     public class IndexService : IIndexService
     {
         private readonly IUserIndexQueue _userIndexQueue;
-        private readonly UpdateService _updateService;
+        private readonly GlobalIndexService _globalIndexService;
 
-        public IndexService(IUserIndexQueue userIndexQueue, UpdateService updateService)
+        public IndexService(IUserIndexQueue userIndexQueue, GlobalIndexService indexService)
         {
             this._userIndexQueue = userIndexQueue;
             this._userIndexQueue.UsersToIndex.SubscribeAsync(OnNextAsync);
-            this._updateService = updateService;
+            this._globalIndexService = indexService;
         }
 
         private async Task OnNextAsync(User user)
         {
-            await this._updateService.IndexUser(user);
+            await this._globalIndexService.IndexUser(user);
         }
 
         public void IndexGuild(IReadOnlyList<User> users)
@@ -41,13 +41,12 @@ namespace FMBot.Bot.Services
             this._userIndexQueue.Publish(users.ToList());
         }
 
-        public async Task UpdateUser(User user)
+        public async Task IndexUser(User user)
         {
-            Console.WriteLine($"Starting update for {user.UserNameLastFM}");
+            Console.WriteLine($"Starting index for {user.UserNameLastFM}");
 
-            await this._updateService.UpdateUser(user);
+            await this._globalIndexService.IndexUser(user);
         }
-
 
         public async Task StoreGuildUsers(IGuild guild, IReadOnlyCollection<IGuildUser> guildUsers)
         {

--- a/src/FMBot.Bot/Services/IndexService.cs
+++ b/src/FMBot.Bot/Services/IndexService.cs
@@ -6,7 +6,6 @@ using Discord;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
-using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Domain.Models;
 using FMBot.LastFM.Services;
@@ -33,6 +32,7 @@ namespace FMBot.Bot.Services
 
         private async Task OnNextAsync(User user)
         {
+            Log.Verbose("User next up for index is {UserNameLastFM}", user.UserNameLastFM);
             await this._globalIndexService.IndexUser(user);
         }
 
@@ -137,13 +137,11 @@ namespace FMBot.Bot.Services
         {
             var userIds = guildUsers.Select(s => s.Id).ToList();
 
-            var tooRecent = DateTime.UtcNow.Add(-Constants.GuildIndexCooldown);
-
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             return await db.Users
                 .Include(i => i.Artists)
                 .Where(w => userIds.Contains(w.DiscordUserId)
-                && (w.LastIndexed == null || w.LastIndexed <= tooRecent))
+                && (w.LastIndexed == null || w.LastUpdated == null))
                 .ToListAsync();
         }
 
@@ -151,13 +149,11 @@ namespace FMBot.Bot.Services
         {
             var userIds = guildUsers.Select(s => s.Id).ToList();
 
-            var indexCooldown = DateTime.UtcNow.Add(-Constants.GuildIndexCooldown);
-
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             return await db.Users
                 .AsQueryable()
                 .Where(w => userIds.Contains(w.DiscordUserId)
-                    && w.LastIndexed != null && w.LastIndexed >= indexCooldown)
+                    && w.LastIndexed != null)
                 .CountAsync();
         }
     }

--- a/src/FMBot.Bot/Services/IndexService.cs
+++ b/src/FMBot.Bot/Services/IndexService.cs
@@ -31,7 +31,7 @@ namespace FMBot.Bot.Services
 
         private async Task OnNextAsync(User user)
         {
-            await this._updateService.InitialUserIndex(user);
+            await this._updateService.IndexUser(user);
         }
 
         public void IndexGuild(IReadOnlyList<User> users)
@@ -39,6 +39,13 @@ namespace FMBot.Bot.Services
             Console.WriteLine($"Starting artist update for {users.Count} users");
 
             this._userIndexQueue.Publish(users.ToList());
+        }
+
+        public async Task UpdateUser(User user)
+        {
+            Console.WriteLine($"Starting update for {user.UserNameLastFM}");
+
+            await this._updateService.UpdateUser(user);
         }
 
 
@@ -73,6 +80,8 @@ namespace FMBot.Bot.Services
             await deleteCurrentArtists.ExecuteNonQueryAsync().ConfigureAwait(false);
 
             await copyHelper.SaveAllAsync(connection, users).ConfigureAwait(false);
+
+            Console.WriteLine($"Stored guild users");
         }
 
         public async Task<IReadOnlyList<User>> GetUsersToIndex(IReadOnlyCollection<IGuildUser> guildUsers)

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -193,7 +193,14 @@ namespace FMBot.Bot.Services
                     if (string.IsNullOrEmpty(ConfigData.Data.Bot.Status))
                     {
                         Log.Information("Updating status");
-                        await client.SetGameAsync($"{ConfigData.Data.Bot.Prefix} | {client.Guilds.Count} servers | fmbot.xyz");
+                        if (!PublicProperties.IssuesAtLastFM)
+                        {
+                            await client.SetGameAsync($"{ConfigData.Data.Bot.Prefix} | {client.Guilds.Count} servers | fmbot.xyz");
+                        }
+                        else
+                        {
+                            await client.SetGameAsync($"⚠️ Last.fm is currently experiencing issues -> twitter.com/lastfmstatus");
+                        }
                     }
                 },
                 null,

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -10,6 +10,7 @@ using DiscordBotsList.Api;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
+using FMBot.Domain;
 using FMBot.LastFM.Services;
 using IF.Lastfm.Core.Api.Enums;
 using Serilog;
@@ -20,7 +21,6 @@ namespace FMBot.Bot.Services
 {
     public class TimerService
     {
-        private readonly Logger.Logger _logger;
         private readonly Timer _timer;
         private readonly Timer _externalStatsTimer;
         private readonly Timer _internalStatsTimer;
@@ -36,12 +36,11 @@ namespace FMBot.Bot.Services
 
         private string _trackString = "";
 
-        public TimerService(DiscordShardedClient client, Logger.Logger logger, ILastfmApi lastfmApi)
+        public TimerService(DiscordShardedClient client, ILastfmApi lastfmApi, LastFMService lastFmService)
         {
-            this._logger = logger;
             this._lastfmApi = lastfmApi;
             this._client = client;
-            this._lastFMService = new LastFMService(this._lastfmApi);
+            this._lastFMService = lastFmService;
             this._userService = new UserService();
             this._guildService = new GuildService();
 

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -248,7 +248,7 @@ namespace FMBot.Bot.Services
                     }
 
                     Log.Information("Getting users to update");
-                    var timeToUpdate = DateTime.UtcNow.AddHours(-ConfigData.Data.LastFm.UserUpdateFrequencyInHours.GetValueOrDefault(24));
+                    var timeToUpdate = DateTime.UtcNow.AddHours(-ConfigData.Data.LastFm.UserUpdateFrequencyInHours.GetValueOrDefault(ConfigData.Data.LastFm.UserUpdateFrequencyInHours.Value));
 
                     var usersToUpdate = await this._updateService.GetOutdatedUsers(timeToUpdate);
                     Log.Information($"Found {usersToUpdate.Count} outdated users, adding them to queue");

--- a/src/FMBot.Bot/Services/UpdateService.cs
+++ b/src/FMBot.Bot/Services/UpdateService.cs
@@ -1,19 +1,8 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
-using Discord;
-using FMBot.Bot.Configurations;
-using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
-using FMBot.Bot.Models;
-using FMBot.Bot.Resources;
 using FMBot.LastFM.Services;
 using FMBot.Persistence.Domain.Models;
-using FMBot.Persistence.EntityFrameWork;
-using Microsoft.EntityFrameworkCore;
-using Npgsql;
-using PostgreSQLCopyHelper;
 
 namespace FMBot.Bot.Services
 {
@@ -26,11 +15,11 @@ namespace FMBot.Bot.Services
             this._globalUpdateService = updateService;
         }
 
-        public async Task UpdateUser(User user)
+        public async Task<int> UpdateUser(User user)
         {
             Console.WriteLine($"Starting update for {user.UserNameLastFM}");
 
-            await this._globalUpdateService.UpdateUser(user);
+            return await this._globalUpdateService.UpdateUser(user);
         }
     }
 }

--- a/src/FMBot.Bot/Services/UpdateService.cs
+++ b/src/FMBot.Bot/Services/UpdateService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
+using FMBot.Bot.Interfaces;
+using FMBot.Bot.Models;
+using FMBot.Bot.Resources;
+using FMBot.LastFM.Services;
+using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using PostgreSQLCopyHelper;
+
+namespace FMBot.Bot.Services
+{
+    public class UpdateService : IUpdateService
+    {
+        private readonly GlobalUpdateService _globalUpdateService;
+
+        public UpdateService(GlobalUpdateService updateService)
+        {
+            this._globalUpdateService = updateService;
+        }
+
+        public async Task UpdateUser(User user)
+        {
+            Console.WriteLine($"Starting update for {user.UserNameLastFM}");
+
+            await this._globalUpdateService.UpdateUser(user);
+        }
+    }
+}

--- a/src/FMBot.Bot/Services/UpdateService.cs
+++ b/src/FMBot.Bot/Services/UpdateService.cs
@@ -1,18 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.LastFM.Services;
 using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using Microsoft.EntityFrameworkCore;
 using Serilog;
 
 namespace FMBot.Bot.Services
 {
     public class UpdateService : IUpdateService
     {
+        private readonly IUserUpdateQueue _userUpdateQueue;
         private readonly GlobalUpdateService _globalUpdateService;
 
-        public UpdateService(GlobalUpdateService updateService)
+        public UpdateService(IUserUpdateQueue userUpdateQueue, GlobalUpdateService updateService)
         {
+            this._userUpdateQueue = userUpdateQueue;
+            this._userUpdateQueue.UsersToUpdate.SubscribeAsync(OnNextAsync);
             this._globalUpdateService = updateService;
+        }
+
+        private async Task OnNextAsync(User user)
+        {
+            Log.Verbose("User next up for update is {UserNameLastFM}", user.UserNameLastFM);
+            await this._globalUpdateService.UpdateUser(user);
+        }
+
+        public void AddUsersToUpdateQueue(IReadOnlyList<User> users)
+        {
+            Log.Information($"Adding {users.Count} users to update queue");
+
+            this._userUpdateQueue.Publish(users.ToList());
         }
 
         public async Task<int> UpdateUser(User user)
@@ -20,6 +43,17 @@ namespace FMBot.Bot.Services
             Log.Information("Starting index for {UserNameLastFM}", user.UserNameLastFM);
 
             return await this._globalUpdateService.UpdateUser(user);
+        }
+
+        public async Task<IReadOnlyList<User>> GetOutdatedUsers(DateTime timeLastUpdated)
+        {
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            return await db.Users
+                    .AsQueryable()
+                    .Where(f => f.LastIndexed != null &&
+                                f.LastUpdated != null &&
+                                f.LastUpdated <= timeLastUpdated)
+                    .ToListAsync();
         }
     }
 }

--- a/src/FMBot.Bot/Services/UpdateService.cs
+++ b/src/FMBot.Bot/Services/UpdateService.cs
@@ -1,8 +1,8 @@
-using System;
 using System.Threading.Tasks;
 using FMBot.Bot.Interfaces;
 using FMBot.LastFM.Services;
 using FMBot.Persistence.Domain.Models;
+using Serilog;
 
 namespace FMBot.Bot.Services
 {
@@ -17,7 +17,7 @@ namespace FMBot.Bot.Services
 
         public async Task<int> UpdateUser(User user)
         {
-            Console.WriteLine($"Starting update for {user.UserNameLastFM}");
+            Log.Information("Starting index for {UserNameLastFM}", user.UserNameLastFM);
 
             return await this._globalUpdateService.UpdateUser(user);
         }

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using FMBot.Bot.Configurations;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -8,6 +8,7 @@ using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
+using Serilog;
 
 namespace FMBot.Bot.Services
 {
@@ -273,13 +274,28 @@ namespace FMBot.Bot.Services
         public async Task DeleteUser(int userID)
         {
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
-            var user = await db.Users
-                .AsQueryable()
-                .FirstOrDefaultAsync(f => f.UserId == userID);
 
-            db.Users.Remove(user);
+            try
+            {
+                var user = await db.Users
+                    .Include(i => i.Artists)
+                    .Include(i => i.Albums)
+                    .Include(i => i.Tracks)
+                    .FirstOrDefaultAsync(f => f.UserId == userID);
 
-            await db.SaveChangesAsync();
+                db.UserArtists.RemoveRange(user.Artists);
+                db.UserAlbums.RemoveRange(user.Albums);
+                db.UserTracks.RemoveRange(user.Tracks);
+                db.Users.Remove(user);
+
+                await db.SaveChangesAsync();
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Error while deleting user!");
+                throw;
+            }
+            
         }
 
         public async Task<int> GetTotalUserCountAsync()

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -36,10 +36,11 @@ namespace FMBot.Bot.Services
         public async Task<User> GetFullUserAsync(IUser discordUser)
         {
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
-            return await db.Users
-                .Include(i => i.Artists)
+            var query = db.Users
                 .Include(i => i.Friends)
-                .Include(i => i.FriendedByUsers)
+                .Include(i => i.FriendedByUsers);
+
+            return await query
                 .FirstOrDefaultAsync(f => f.DiscordUserId == discordUser.Id);
         }
 
@@ -295,7 +296,7 @@ namespace FMBot.Bot.Services
                 Log.Error(e, "Error while deleting user!");
                 throw;
             }
-            
+
         }
 
         public async Task<int> GetTotalUserCountAsync()

--- a/src/FMBot.Bot/Services/WhoKnows/WhoKnowsAlbumService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/WhoKnowsAlbumService.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord.Commands;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Models;
+using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using Microsoft.EntityFrameworkCore;
+
+namespace FMBot.Bot.Services.WhoKnows
+{
+    public class WhoKnowsAlbumService
+    {
+        public async Task<IList<WhoKnowsObjectWithUser>> GetIndexedUsersForAlbum(ICommandContext context,
+            IReadOnlyList<User> guildUsers, string artistName, string albumName)
+        {
+            var userIds = guildUsers.Select(s => s.UserId);
+
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            var albums = await db.UserAlbums
+                .Include(i => i.User)
+                .Where(w => w.Name.ToLower() == albumName.ToLower() &&
+                            w.ArtistName.ToLower() == artistName.ToLower()
+                            && userIds.Contains(w.UserId))
+                .OrderByDescending(o => o.Playcount)
+                .Take(14)
+                .ToListAsync();
+
+            var whoKnowsAlbumList = new List<WhoKnowsObjectWithUser>();
+
+            foreach (var album in albums)
+            {
+                var discordUser = await context.Guild.GetUserAsync(album.User.DiscordUserId);
+                if (discordUser != null)
+                {
+                    whoKnowsAlbumList.Add(new WhoKnowsObjectWithUser
+                    {
+                        Name = $"{album.ArtistName} - {album.Name}",
+                        DiscordName = discordUser.Nickname ?? discordUser.Username,
+                        Playcount = album.Playcount,
+                        DiscordUserId = album.User.DiscordUserId,
+                        LastFMUsername = album.User.UserNameLastFM,
+                        UserId = album.UserId,
+                    });
+                }
+            }
+
+            return whoKnowsAlbumList;
+        }
+
+        public async Task<IList<ListArtist>> GetTopAlbumsForGuild(IReadOnlyList<User> guildUsers)
+        {
+            var userIds = guildUsers.Select(s => s.UserId);
+
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            return await db.UserAlbums
+                .AsQueryable()
+                .Where(w => userIds.Contains(w.UserId))
+                .GroupBy(o => o.Name)
+                .OrderByDescending(o => o.Sum(s => s.Playcount))
+                .Take(14)
+                .Select(s => new ListArtist
+                {
+                    ArtistName = s.Key,
+                    Playcount = s.Sum(s => s.Playcount),
+                    ListenerCount = s.Count()
+                })
+                .ToListAsync();
+        }
+    }
+}

--- a/src/FMBot.Bot/Services/WhoKnows/WhoKnowsArtistService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/WhoKnowsArtistService.cs
@@ -1,92 +1,18 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Discord;
 using Discord.Commands;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Models;
-using FMBot.Bot.Resources;
-using FMBot.LastFM.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 
-namespace FMBot.Bot.Services
+namespace FMBot.Bot.Services.WhoKnows
 {
-    public class WhoKnowsService
+    public class WhoKnowsArtistService
     {
-        public static IList<ArtistWithUser> AddUserToIndexList(IList<ArtistWithUser> artists, User userSettings, IGuildUser user, ArtistResponse artist)
-        {
-            artists.Add(new ArtistWithUser
-            {
-                UserId = userSettings.UserId,
-                ArtistName = artist.Artist.Name,
-                Playcount = Convert.ToInt32(artist.Artist.Stats.Userplaycount.Value),
-                LastFMUsername = userSettings.UserNameLastFM,
-                DiscordUserId = userSettings.DiscordUserId,
-                DiscordName = user.Nickname ?? user.Username
-            });
-
-            return artists.OrderByDescending(o => o.Playcount).ToList();
-        }
-
-        public static string ArtistWithUserToStringList(IList<ArtistWithUser> artists, ArtistResponse artistResponse, int userId)
-        {
-            var reply = "";
-
-            var artistsCount = artists.Count;
-            if (artistsCount > 14)
-            {
-                artistsCount = 14;
-            }
-
-            for (var index = 0; index < artistsCount; index++)
-            {
-                var artist = artists[index];
-
-                var nameWithLink = NameWithLink(artist);
-                var playString = GetPlaysString(artist.Playcount);
-
-                if (index == 0)
-                {
-                    reply += $"👑  {nameWithLink}";
-                }
-                else
-                {
-                    reply += $" {index + 1}.  {nameWithLink} ";
-                }
-                if (artist.UserId != userId)
-                {
-                    reply += $"- **{artist.Playcount}** {playString}\n";
-                }
-                else
-                {
-                    reply += $"- **{artistResponse.Artist.Stats.Userplaycount}** {playString}\n";
-                }
-            }
-
-            if (artists.Count == 1)
-            {
-                reply += $"\nNobody else has this artist in their top {Constants.ArtistsToIndex} artists.";
-            }
-
-            return reply;
-        }
-
-        private static string NameWithLink(ArtistWithUser artist)
-        {
-            var discordName = artist.DiscordName.Replace("(", "").Replace(")", "").Replace("[", "").Replace("]", "");
-            var nameWithLink = $"[{discordName}]({Constants.LastFMUserUrl}{artist.LastFMUsername})";
-            return nameWithLink;
-        }
-
-        private static string GetPlaysString(int artistPlaycount)
-        {
-            return artistPlaycount == 1 ? "play" : "plays";
-        }
-
-        public async Task<IList<ArtistWithUser>> GetIndexedUsersForArtist(ICommandContext context,
+        public async Task<IList<WhoKnowsObjectWithUser>> GetIndexedUsersForArtist(ICommandContext context,
             IReadOnlyList<User> guildUsers, string artistName)
         {
             var userIds = guildUsers.Select(s => s.UserId);
@@ -100,16 +26,16 @@ namespace FMBot.Bot.Services
                 .Take(14)
                 .ToListAsync();
 
-            var returnArtists = new List<ArtistWithUser>();
+            var whoKnowsArtistList = new List<WhoKnowsObjectWithUser>();
 
             foreach (var artist in artists)
             {
                 var discordUser = await context.Guild.GetUserAsync(artist.User.DiscordUserId);
                 if (discordUser != null)
                 {
-                    returnArtists.Add(new ArtistWithUser
+                    whoKnowsArtistList.Add(new WhoKnowsObjectWithUser
                     {
-                        ArtistName = artist.Name,
+                        Name = artist.Name,
                         DiscordName = discordUser.Nickname ?? discordUser.Username,
                         Playcount = artist.Playcount,
                         DiscordUserId = artist.User.DiscordUserId,
@@ -119,7 +45,7 @@ namespace FMBot.Bot.Services
                 }
             }
 
-            return returnArtists;
+            return whoKnowsArtistList;
         }
 
         public async Task<IList<ListArtist>> GetTopArtistsForGuild(IReadOnlyList<User> guildUsers)
@@ -141,7 +67,6 @@ namespace FMBot.Bot.Services
                 })
                 .ToListAsync();
         }
-
 
         public async Task<int> GetArtistListenerCountForServer(IReadOnlyList<User> guildUsers, string artistName)
         {

--- a/src/FMBot.Bot/Services/WhoKnows/WhoKnowsService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/WhoKnowsService.cs
@@ -69,11 +69,6 @@ namespace FMBot.Bot.Services.WhoKnows
                 reply += $"- **{artist.Playcount}** {playString}\n";
             }
 
-            if (user.Count == 1)
-            {
-                reply += $"\nNobody else has this artist in their top {Constants.ArtistsToIndex} artists.";
-            }
-
             return reply;
         }
 

--- a/src/FMBot.Bot/Services/WhoKnows/WhoKnowsService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/WhoKnowsService.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Models;
+using FMBot.Bot.Resources;
+using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using Microsoft.EntityFrameworkCore;
+
+namespace FMBot.Bot.Services.WhoKnows
+{
+    public class WhoKnowsService
+    {
+        public static IList<WhoKnowsObjectWithUser> AddOrReplaceUserToIndexList(IList<WhoKnowsObjectWithUser> users, User userSettings, IGuildUser user, string name, long? playcount)
+        {
+            var existingRecord = users.FirstOrDefault(f => f.UserId == userSettings.UserId);
+            if (existingRecord != null)
+            {
+                users.Remove(existingRecord);
+            }
+
+            var userPlaycount = int.Parse(playcount.GetValueOrDefault(0).ToString());
+            if (users.Count != 14)
+            {
+                users.Add(new WhoKnowsObjectWithUser
+                {
+                    UserId = userSettings.UserId,
+                    Name = name,
+                    Playcount = userPlaycount,
+                    LastFMUsername = userSettings.UserNameLastFM,
+                    DiscordUserId = userSettings.DiscordUserId,
+                    DiscordName = user.Nickname ?? user.Username
+                });
+            }
+
+            return users.OrderByDescending(o => o.Playcount).ToList();
+        }
+
+        public static string WhoKnowsListToString(IList<WhoKnowsObjectWithUser> user)
+        {
+            var reply = "";
+
+            var artistsCount = user.Count;
+            if (artistsCount > 14)
+            {
+                artistsCount = 14;
+            }
+
+            for (var index = 0; index < artistsCount; index++)
+            {
+                var artist = user[index];
+
+                var nameWithLink = NameWithLink(artist);
+                var playString = GetPlaysString(artist.Playcount);
+
+                if (index == 0)
+                {
+                    reply += $"👑  {nameWithLink}";
+                }
+                else
+                {
+                    reply += $" {index + 1}.  {nameWithLink} ";
+                }
+
+                reply += $"- **{artist.Playcount}** {playString}\n";
+            }
+
+            if (user.Count == 1)
+            {
+                reply += $"\nNobody else has this artist in their top {Constants.ArtistsToIndex} artists.";
+            }
+
+            return reply;
+        }
+
+        private static string NameWithLink(WhoKnowsObjectWithUser user)
+        {
+            var discordName = user.DiscordName.Replace("(", "").Replace(")", "").Replace("[", "").Replace("]", "");
+            var nameWithLink = $"[{discordName}]({Constants.LastFMUserUrl}{user.LastFMUsername})";
+            return nameWithLink;
+        }
+
+        private static string GetPlaysString(int playcount)
+        {
+            return playcount == 1 ? "play" : "plays";
+        }
+    }
+}

--- a/src/FMBot.Bot/Services/WhoKnows/WhoKnowsTrackService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/WhoKnowsTrackService.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord.Commands;
+using FMBot.Bot.Configurations;
+using FMBot.Bot.Models;
+using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using Microsoft.EntityFrameworkCore;
+
+namespace FMBot.Bot.Services.WhoKnows
+{
+    public class WhoKnowsTrackService
+    {
+        public async Task<IList<WhoKnowsObjectWithUser>> GetIndexedUsersForTrack(ICommandContext context,
+            IReadOnlyList<User> guildUsers, string artistName, string trackName)
+        {
+            var userIds = guildUsers.Select(s => s.UserId);
+
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            var tracks = await db.UserTracks
+                .Include(i => i.User)
+                .Where(w => w.Name.ToLower() == trackName.ToLower() &&
+                            w.ArtistName.ToLower() == artistName.ToLower()
+                            && userIds.Contains(w.UserId))
+                .OrderByDescending(o => o.Playcount)
+                .Take(14)
+                .ToListAsync();
+
+            var whoKnowsTrackList = new List<WhoKnowsObjectWithUser>();
+
+            foreach (var track in tracks)
+            {
+                var discordUser = await context.Guild.GetUserAsync(track.User.DiscordUserId);
+                if (discordUser != null)
+                {
+                    whoKnowsTrackList.Add(new WhoKnowsObjectWithUser
+                    {
+                        Name = $"{track.ArtistName} - {track.Name}",
+                        DiscordName = discordUser.Nickname ?? discordUser.Username,
+                        Playcount = track.Playcount,
+                        DiscordUserId = track.User.DiscordUserId,
+                        LastFMUsername = track.User.UserNameLastFM,
+                        UserId = track.UserId,
+                    });
+                }
+            }
+
+            return whoKnowsTrackList;
+        }
+
+        public async Task<IList<ListArtist>> GetTopTracksForGuild(IReadOnlyList<User> guildUsers)
+        {
+            var userIds = guildUsers.Select(s => s.UserId);
+
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            return await db.UserTracks
+                .AsQueryable()
+                .Where(w => userIds.Contains(w.UserId))
+                .GroupBy(o => o.Name)
+                .OrderByDescending(o => o.Sum(s => s.Playcount))
+                .Take(14)
+                .Select(s => new ListArtist
+                {
+                    ArtistName = s.Key,
+                    Playcount = s.Sum(s => s.Playcount),
+                    ListenerCount = s.Count()
+                })
+                .ToListAsync();
+        }
+    }
+}

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Net.Http;
 using System.Threading.Tasks;
 using CXuesong.Uel.Serilog.Sinks.Discord;
 using Discord;

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -98,6 +98,7 @@ namespace FMBot.Bot
                 .AddSingleton<WhoKnowsService>()
                 .AddSingleton<IChartService, ChartService>()
                 .AddSingleton<IIndexService, IndexService>()
+                .AddSingleton<IUpdateService, UpdateService>()
                 .AddSingleton<GuildService>()
                 .AddSingleton<UserService>()
                 .AddSingleton(logger)
@@ -109,7 +110,8 @@ namespace FMBot.Bot
             services
                 .AddTransient<ILastfmApi, LastfmApi>()
                 .AddTransient<LastFMService>()
-                .AddSingleton<UpdateService>();
+                .AddSingleton<GlobalUpdateService>()
+                .AddSingleton<GlobalIndexService>();
 
             using var context = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             try

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -11,6 +11,7 @@ using FMBot.Bot.Handlers;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
 using FMBot.Bot.Services;
+using FMBot.Bot.Services.WhoKnows;
 using FMBot.LastFM.Services;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
@@ -94,11 +95,14 @@ namespace FMBot.Bot
                 .AddSingleton<IPrefixService, PrefixService>()
                 .AddSingleton<IDisabledCommandService, DisabledCommandService>()
                 .AddSingleton<IUserIndexQueue, UserIndexQueue>()
+                .AddSingleton<IUserUpdateQueue, UserUpdateQueue>()
                 .AddSingleton<ArtistsService>()
                 .AddSingleton<WhoKnowsService>()
+                .AddSingleton<WhoKnowsArtistService>()
+                .AddSingleton<WhoKnowsAlbumService>()
+                .AddSingleton<WhoKnowsTrackService>()
                 .AddSingleton<IChartService, ChartService>()
                 .AddSingleton<IIndexService, IndexService>()
-                .AddSingleton<IUpdateService, UpdateService>()
                 .AddSingleton<GuildService>()
                 .AddSingleton<UserService>()
                 .AddSingleton(logger)
@@ -111,7 +115,8 @@ namespace FMBot.Bot
                 .AddTransient<ILastfmApi, LastfmApi>()
                 .AddTransient<LastFMService>()
                 .AddSingleton<GlobalUpdateService>()
-                .AddSingleton<GlobalIndexService>();
+                .AddSingleton<GlobalIndexService>()
+                .AddSingleton<IUpdateService, UpdateService>();
 
             using var context = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             try

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 using CXuesong.Uel.Serilog.Sinks.Discord;
 using Discord;
@@ -107,6 +108,7 @@ namespace FMBot.Bot
             // These services can only be added after the config is loaded
             services
                 .AddTransient<ILastfmApi, LastfmApi>()
+                .AddTransient<LastFMService>()
                 .AddSingleton<UpdateService>();
 
             using var context = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);

--- a/src/FMBot.BotLists/Services/BotListUpdater.cs
+++ b/src/FMBot.BotLists/Services/BotListUpdater.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Cache;

--- a/src/FMBot.DbMigration/OldDatabase/Entities/Guilds.cs
+++ b/src/FMBot.DbMigration/OldDatabase/Entities/Guilds.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.DbMigration.OldDatabase.Entities

--- a/src/FMBot.DbMigration/OldDatabase/Entities/Users.cs
+++ b/src/FMBot.DbMigration/OldDatabase/Entities/Users.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.DbMigration.OldDatabase.Entities

--- a/src/FMBot.Discord.sln
+++ b/src/FMBot.Discord.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMBot.Persistence.Domain", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMBot.LastFM.Domain", "FMBot.LastFM.Domain\FMBot.LastFM.Domain.csproj", "{FE7500D8-093E-405A-B767-2A9C49D8DE7F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FMBot.Domain", "FMBot.Domain\FMBot.Domain.csproj", "{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMBot.Domain", "FMBot.Domain\FMBot.Domain.csproj", "{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/FMBot.Discord.sln
+++ b/src/FMBot.Discord.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMBot.Persistence.Domain", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMBot.LastFM.Domain", "FMBot.LastFM.Domain\FMBot.LastFM.Domain.csproj", "{FE7500D8-093E-405A-B767-2A9C49D8DE7F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FMBot.Domain", "FMBot.Domain\FMBot.Domain.csproj", "{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -69,6 +71,10 @@ Global
 		{FE7500D8-093E-405A-B767-2A9C49D8DE7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE7500D8-093E-405A-B767-2A9C49D8DE7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE7500D8-093E-405A-B767-2A9C49D8DE7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBC1F57B-4FA7-400C-B6F8-86700507F9B4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/FMBot.Discord.sln.DotSettings
+++ b/src/FMBot.Discord.sln.DotSettings
@@ -1,3 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=autocorrect/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playcount/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scrobble/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spotify/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/FMBot.Domain/FMBot.Domain.csproj
+++ b/src/FMBot.Domain/FMBot.Domain.csproj
@@ -5,7 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FMBot.Domain\FMBot.Domain.csproj" />
+    <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
+    <PackageReference Include="prometheus-net" Version="3.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/FMBot.Domain/Models/ChartTimePeriod.cs
+++ b/src/FMBot.Domain/Models/ChartTimePeriod.cs
@@ -1,4 +1,4 @@
-namespace FMBot.Persistence.Domain.Models
+namespace FMBot.Domain.Models
 {
     public enum ChartTimePeriod
     {

--- a/src/FMBot.Domain/Models/CommandResponse.cs
+++ b/src/FMBot.Domain/Models/CommandResponse.cs
@@ -16,6 +16,14 @@ namespace FMBot.Domain.Models
 
         Error = 7,
 
-        NoScrobbles = 8
+        NoScrobbles = 8,
+
+        NoPermission = 9,
+
+        Cooldown = 10,
+
+        IndexRequired = 11,
+
+        LastFmError = 12
     }
 }

--- a/src/FMBot.Domain/Models/CommandResponse.cs
+++ b/src/FMBot.Domain/Models/CommandResponse.cs
@@ -14,6 +14,8 @@ namespace FMBot.Domain.Models
 
         NotSupportedInDm = 6,
 
-        Error = 7
+        Error = 7,
+
+        NoScrobbles = 8
     }
 }

--- a/src/FMBot.Domain/Models/CommandResponse.cs
+++ b/src/FMBot.Domain/Models/CommandResponse.cs
@@ -1,0 +1,19 @@
+namespace FMBot.Domain.Models
+{
+    public enum CommandResponse
+    {
+        Ok = 1,
+
+        Help = 2,
+
+        WrongInput = 3,
+
+        UsernameNotSet = 4,
+
+        NotFound = 5,
+
+        NotSupportedInDm = 6,
+
+        Error = 7
+    }
+}

--- a/src/FMBot.Domain/Models/SettingsModel.cs
+++ b/src/FMBot.Domain/Models/SettingsModel.cs
@@ -1,7 +1,6 @@
-using FMBot.Persistence.Domain.Models;
 using IF.Lastfm.Core.Api.Enums;
 
-namespace FMBot.Bot.Models
+namespace FMBot.Domain.Models
 {
     public class SettingsModel
     {

--- a/src/FMBot.Domain/PublicProperties.cs
+++ b/src/FMBot.Domain/PublicProperties.cs
@@ -1,0 +1,7 @@
+namespace FMBot.Domain
+{
+    public static class PublicProperties
+    {
+        public static bool IssuesAtLastFM = false;
+    }
+}

--- a/src/FMBot.Domain/Statistics.cs
+++ b/src/FMBot.Domain/Statistics.cs
@@ -1,6 +1,6 @@
 using Prometheus;
 
-namespace FMBot.Bot.Resources
+namespace FMBot.Domain
 {
     public static class Statistics
     {

--- a/src/FMBot.LastFM/FMBot.LastFM.csproj
+++ b/src/FMBot.LastFM/FMBot.LastFM.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Inflatable.Lastfm" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.6" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Npgsql" Version="4.1.4" />

--- a/src/FMBot.LastFM/FMBot.LastFM.csproj
+++ b/src/FMBot.LastFM/FMBot.LastFM.csproj
@@ -17,9 +17,11 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
     <PackageReference Include="PostgreSQLCopyHelper" Version="2.6.3" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FMBot.Domain\FMBot.Domain.csproj" />
     <ProjectReference Include="..\FMBot.LastFM.Domain\FMBot.LastFM.Domain.csproj" />
     <ProjectReference Include="..\FMBot.Persistence.Domain\FMBot.Persistence.Domain.csproj" />
     <ProjectReference Include="..\FMBot.Persistence.EntityFrameWork\FMBot.Persistence.EntityFrameWork.csproj" />

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -38,7 +38,7 @@ namespace FMBot.LastFM.Services
 
         public async Task IndexUser(User user)
         {
-            Thread.Sleep(6000);
+            Thread.Sleep(7500);
 
             Console.WriteLine($"Starting artist store for {user.UserNameLastFM}");
             var now = DateTime.UtcNow;

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using FMBot.Domain;
 using FMBot.Persistence.Domain.Models;
 using IF.Lastfm.Core.Api;
 using IF.Lastfm.Core.Api.Enums;
@@ -37,19 +38,19 @@ namespace FMBot.LastFM.Services
 
         public async Task IndexUser(User user)
         {
-            Thread.Sleep(5000);
+            Thread.Sleep(6000);
 
             Console.WriteLine($"Starting artist store for {user.UserNameLastFM}");
             var now = DateTime.UtcNow;
 
             var artists = await GetArtistsForUserFromLastFm(user);
-            await InsertArtistsIntoDatabase(artists, user.UserId, now);
+            await InsertArtistsIntoDatabase(artists, user.UserId);
 
             var albums = await GetAlbumsForUserFromLastFm(user);
-            await InsertAlbumsIntoDatabase(albums, user.UserId, now);
+            await InsertAlbumsIntoDatabase(albums, user.UserId);
 
             var tracks = await GetTracksForUserFromLastFm(user);
-            await InsertTracksIntoDatabase(tracks, user.UserId, now);
+            await InsertTracksIntoDatabase(tracks, user.UserId);
 
             var latestScrobbleDate = await GetLatestScrobbleDate(user);
             await SetUserIndexTime(user.UserId, now, latestScrobbleDate);
@@ -66,6 +67,7 @@ namespace FMBot.LastFM.Services
             {
                 var artistResult = await this._lastFMClient.User.GetTopArtists(user.UserNameLastFM,
                     LastStatsTimeSpan.Overall, i, 1000);
+                Statistics.LastfmApiCalls.Inc();
 
                 topArtists.AddRange(artistResult);
 
@@ -80,9 +82,10 @@ namespace FMBot.LastFM.Services
                 return new List<UserArtist>();
             }
 
+            var now = DateTime.UtcNow;
             return topArtists.Select(a => new UserArtist
             {
-                LastUpdated = DateTime.UtcNow,
+                LastUpdated = now,
                 Name = a.Name,
                 Playcount = a.PlayCount.Value,
                 UserId = user.UserId
@@ -95,11 +98,12 @@ namespace FMBot.LastFM.Services
 
             var topAlbums = new List<LastAlbum>();
 
-            const int amountOfApiCalls = 4000 / 1000;
+            const int amountOfApiCalls = 5000 / 1000;
             for (var i = 1; i < amountOfApiCalls + 1; i++)
             {
                 var albumResult = await this._lastFMClient.User.GetTopAlbums(user.UserNameLastFM,
                     LastStatsTimeSpan.Overall, i, 1000);
+                Statistics.LastfmApiCalls.Inc();
 
                 topAlbums.AddRange(albumResult);
 
@@ -114,9 +118,10 @@ namespace FMBot.LastFM.Services
                 return new List<UserAlbum>();
             }
 
+            var now = DateTime.UtcNow;
             return topAlbums.Select(a => new UserAlbum
             {
-                LastUpdated = DateTime.UtcNow,
+                LastUpdated = now,
                 Name = a.Name,
                 ArtistName = a.ArtistName,
                 Playcount = a.PlayCount.Value,
@@ -128,16 +133,17 @@ namespace FMBot.LastFM.Services
         {
             Console.WriteLine($"Getting tracks for user {user.UserNameLastFM}");
 
-            var trackResult = await this.lastFmService.GetTopTracksAsync(user.UserNameLastFM, "overall", 1000, 5);
+            var trackResult = await this.lastFmService.GetTopTracksAsync(user.UserNameLastFM, "overall", 1000, 8);
 
             if (!trackResult.Success || trackResult.Content.TopTracks.Track.Count == 0)
             {
                 return new List<UserTrack>();
             }
 
+            var now = DateTime.UtcNow;
             return trackResult.Content.TopTracks.Track.Select(a => new UserTrack
             {
-                LastUpdated = DateTime.UtcNow,
+                LastUpdated = now,
                 Name = a.Name,
                 ArtistName = a.Artist.Name,
                 Playcount = Convert.ToInt32(a.Playcount),
@@ -145,7 +151,7 @@ namespace FMBot.LastFM.Services
             }).ToList();
         }
 
-        private async Task InsertArtistsIntoDatabase(IReadOnlyList<UserArtist> artists, int userId, DateTime now)
+        private async Task InsertArtistsIntoDatabase(IReadOnlyList<UserArtist> artists, int userId)
         {
             Console.WriteLine($"Inserting artists for user {userId}");
 
@@ -164,7 +170,7 @@ namespace FMBot.LastFM.Services
             await copyHelper.SaveAllAsync(connection, artists).ConfigureAwait(false);
         }
 
-        private async Task InsertAlbumsIntoDatabase(IReadOnlyList<UserAlbum> albums, int userId, DateTime now)
+        private async Task InsertAlbumsIntoDatabase(IReadOnlyList<UserAlbum> albums, int userId)
         {
             Console.WriteLine($"Inserting albums for user {userId}");
 
@@ -184,7 +190,7 @@ namespace FMBot.LastFM.Services
             await copyHelper.SaveAllAsync(connection, albums).ConfigureAwait(false);
         }
 
-        private async Task InsertTracksIntoDatabase(IReadOnlyList<UserTrack> artists, int userId, DateTime now)
+        private async Task InsertTracksIntoDatabase(IReadOnlyList<UserTrack> artists, int userId)
         {
             Console.WriteLine($"Inserting tracks for user {userId}");
 
@@ -207,22 +213,26 @@ namespace FMBot.LastFM.Services
 
         private async Task SetUserIndexTime(int userId, DateTime now, DateTime lastScrobble)
         {
+            Console.WriteLine($"Setting user index time for user {userId}");
+
             await using var connection = new NpgsqlConnection(this._connectionString);
             connection.Open();
 
-            await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_indexed='{now:u}', last_scrobble_update = '{lastScrobble:u}' WHERE user_id = {userId};", connection);
+            await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_indexed='{now:u}', last_updated='{now:u}', last_scrobble_update = '{lastScrobble:u}' WHERE user_id = {userId};", connection);
             await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
         }
 
         private async Task<DateTime> GetLatestScrobbleDate(User user)
         {
             var recentTracks = await this._lastFMClient.User.GetRecentScrobbles(user.UserNameLastFM, count: 1);
-            if (!recentTracks.Success || !recentTracks.Content.Any() || !recentTracks.Content.First().TimePlayed.HasValue)
+            Statistics.LastfmApiCalls.Inc();
+            if (!recentTracks.Success || !recentTracks.Content.Any() || !recentTracks.Content.Any(a => a.TimePlayed.HasValue))
             {
+                Console.WriteLine("Recent track call to get latest scrobble date failed!");
                 return DateTime.UtcNow;
             }
 
-            return recentTracks.Content.First().TimePlayed.Value.DateTime;
+            return recentTracks.Content.First(f => f.TimePlayed.HasValue).TimePlayed.Value.DateTime;
         }
     }
 }

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -82,10 +82,8 @@ namespace FMBot.LastFM.Services
                 return new List<UserArtist>();
             }
 
-            var now = DateTime.UtcNow;
             return topArtists.Select(a => new UserArtist
             {
-                LastUpdated = now,
                 Name = a.Name,
                 Playcount = a.PlayCount.Value,
                 UserId = user.UserId
@@ -118,10 +116,8 @@ namespace FMBot.LastFM.Services
                 return new List<UserAlbum>();
             }
 
-            var now = DateTime.UtcNow;
             return topAlbums.Select(a => new UserAlbum
             {
-                LastUpdated = now,
                 Name = a.Name,
                 ArtistName = a.ArtistName,
                 Playcount = a.PlayCount.Value,
@@ -140,10 +136,8 @@ namespace FMBot.LastFM.Services
                 return new List<UserTrack>();
             }
 
-            var now = DateTime.UtcNow;
             return trackResult.Content.TopTracks.Track.Select(a => new UserTrack
             {
-                LastUpdated = now,
                 Name = a.Name,
                 ArtistName = a.Artist.Name,
                 Playcount = Convert.ToInt32(a.Playcount),
@@ -158,8 +152,7 @@ namespace FMBot.LastFM.Services
             var copyHelper = new PostgreSQLCopyHelper<UserArtist>("public", "user_artists")
                 .MapText("name", x => x.Name)
                 .MapInteger("user_id", x => x.UserId)
-                .MapInteger("playcount", x => x.Playcount)
-                .MapTimeStamp("last_updated", x => x.LastUpdated);
+                .MapInteger("playcount", x => x.Playcount);
 
             await using var connection = new NpgsqlConnection(this._connectionString);
             connection.Open();
@@ -178,8 +171,7 @@ namespace FMBot.LastFM.Services
                 .MapText("name", x => x.Name)
                 .MapText("artist_name", x => x.ArtistName)
                 .MapInteger("user_id", x => x.UserId)
-                .MapInteger("playcount", x => x.Playcount)
-                .MapTimeStamp("last_updated", x => x.LastUpdated);
+                .MapInteger("playcount", x => x.Playcount);
 
             await using var connection = new NpgsqlConnection(this._connectionString);
             connection.Open();
@@ -198,8 +190,7 @@ namespace FMBot.LastFM.Services
                 .MapText("name", x => x.Name)
                 .MapText("artist_name", x => x.ArtistName)
                 .MapInteger("user_id", x => x.UserId)
-                .MapInteger("playcount", x => x.Playcount)
-                .MapTimeStamp("last_updated", x => x.LastUpdated);
+                .MapInteger("playcount", x => x.Playcount);
 
             await using var connection = new NpgsqlConnection(this._connectionString);
             connection.Open();

--- a/src/FMBot.LastFM/Services/GlobalUpdateService.cs
+++ b/src/FMBot.LastFM/Services/GlobalUpdateService.cs
@@ -1,0 +1,170 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
+using IF.Lastfm.Core.Api;
+using IF.Lastfm.Core.Api.Enums;
+using IF.Lastfm.Core.Objects;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+
+namespace FMBot.LastFM.Services
+{
+    public class GlobalUpdateService
+
+    {
+        private readonly LastfmClient _lastFMClient;
+
+        private readonly string _key;
+        private readonly string _secret;
+
+        private readonly string _connectionString;
+
+        public GlobalUpdateService(IConfigurationRoot configuration)
+        {
+            this._key = configuration.GetSection("LastFm:Key").Value;
+            this._secret = configuration.GetSection("LastFm:Secret").Value;
+            this._connectionString = configuration.GetSection("Database:ConnectionString").Value;
+            this._lastFMClient = new LastfmClient(this._key, this._secret);
+        }
+
+
+        public async Task UpdateUser(User user)
+        {
+            Thread.Sleep(1000);
+
+            Console.WriteLine($"Updating {user.UserNameLastFM}");
+
+            var recentTracks = await this._lastFMClient.User.GetRecentScrobbles(user.UserNameLastFM, count: 1000);
+            if (!recentTracks.Success || !recentTracks.Content.Any())
+            {
+                return;
+            }
+
+            var newScrobbles = recentTracks.Content
+                .Where(w => w.TimePlayed.Value.DateTime > user.LastScrobbleUpdate)
+                .ToList();
+
+            if (!newScrobbles.Any())
+            {
+                Console.WriteLine($"No new scrobbles for {user.UserNameLastFM}");
+                return;
+            }
+
+            await UpdateArtistsForUser(user, newScrobbles);
+
+            await UpdateAlbumsForUser(user, newScrobbles);
+
+            await UpdateTracksForUser(user, newScrobbles);
+
+            var latestScrobbleDate = recentTracks.Content.OrderByDescending(o => o.TimePlayed.Value.DateTime).First().TimePlayed.Value.DateTime;
+            await SetUserUpdateTime(user.UserId, DateTime.UtcNow, latestScrobbleDate);
+        }
+
+        private async Task UpdateArtistsForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var artist in newScrobbles.GroupBy(g => g.ArtistName))
+            {
+                var alias = await db.ArtistAliases
+                    .Include(i => i.Artist)
+                    .FirstOrDefaultAsync(f =>
+                        f.Alias.ToLower() == artist.Key.ToLower());
+
+                var artistName = alias != null ? alias.Artist.Name : artist.Key;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var updateArtistPlaycount =
+                    new NpgsqlCommand(
+                        $"UPDATE public.user_artists SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name);",
+                        connection);
+
+                updateArtistPlaycount.Parameters.AddWithValue("playcountToAdd", artist.Count());
+                updateArtistPlaycount.Parameters.AddWithValue("userId", user.UserId);
+                updateArtistPlaycount.Parameters.AddWithValue("name", artistName);
+
+                await updateArtistPlaycount.ExecuteNonQueryAsync().ConfigureAwait(false);
+                Console.WriteLine($"Adding {artist.Count()} plays to {artistName} for {user.UserNameLastFM}");
+            }
+
+            Console.WriteLine($"Updated artists for {user.UserNameLastFM}");
+        }
+
+        private async Task UpdateAlbumsForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var album in newScrobbles.GroupBy(x => new { x.ArtistName, x.AlbumName }))
+            {
+                var alias = await db.ArtistAliases
+                    .Include(i => i.Artist)
+                    .FirstOrDefaultAsync(f =>
+                        f.Alias.ToLower() == album.Key.ArtistName.ToLower());
+
+                var artistName = alias != null ? alias.Artist.Name : album.Key.ArtistName;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var setIndexTime =
+                    new NpgsqlCommand(
+                        $"UPDATE public.user_albums SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name) AND UPPER(artist_name) = UPPER(@artistName) ;",
+                        connection);
+
+                setIndexTime.Parameters.AddWithValue("playcountToAdd", album.Count());
+                setIndexTime.Parameters.AddWithValue("userId", user.UserId);
+                setIndexTime.Parameters.AddWithValue("name", album.Key.AlbumName);
+                setIndexTime.Parameters.AddWithValue("artistName", artistName);
+
+                await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            Console.WriteLine($"Updated albums for {user.UserNameLastFM}");
+        }
+
+        private async Task UpdateTracksForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var track in newScrobbles.GroupBy(x => new { x.ArtistName, x.Name }))
+            {
+                var alias = await db.ArtistAliases
+                    .Include(i => i.Artist)
+                    .FirstOrDefaultAsync(f =>
+                        f.Alias.ToLower() == track.Key.ArtistName.ToLower());
+
+                var artistName = alias != null ? alias.Artist.Name : track.Key.ArtistName;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var setIndexTime =
+                    new NpgsqlCommand(
+                        $"UPDATE public.user_tracks SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name) AND UPPER(artist_name) = UPPER(@artistName);",
+                        connection);
+
+                setIndexTime.Parameters.AddWithValue("playcountToAdd", track.Count());
+                setIndexTime.Parameters.AddWithValue("userId", user.UserId);
+                setIndexTime.Parameters.AddWithValue("name", track.Key.Name);
+                setIndexTime.Parameters.AddWithValue("artistName", artistName);
+
+                await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            Console.WriteLine($"Updated tracks for {user.UserNameLastFM}");
+        }
+
+        private async Task SetUserUpdateTime(int userId, DateTime now, DateTime lastScrobble)
+        {
+            await using var connection = new NpgsqlConnection(this._connectionString);
+            connection.Open();
+
+            await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_updated = '{now:u}', last_scrobble_update = '{lastScrobble:u}', WHERE user_id = {userId};", connection);
+            await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/FMBot.LastFM/Services/GlobalUpdateService.cs
+++ b/src/FMBot.LastFM/Services/GlobalUpdateService.cs
@@ -65,7 +65,7 @@ namespace FMBot.LastFM.Services
 
             await UpdateTracksForUser(user, newScrobbles);
 
-            var latestScrobbleDate = recentTracks.Content.OrderByDescending(o => o.TimePlayed.Value.DateTime).First().TimePlayed.Value.DateTime;
+            var latestScrobbleDate = GetLatestScrobbleDate(newScrobbles);
             await SetUserUpdateAndScrobbleTime(user.UserId, DateTime.UtcNow, latestScrobbleDate);
 
             return newScrobbles.Count;
@@ -180,6 +180,17 @@ namespace FMBot.LastFM.Services
 
             await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_updated = '{now:u}' WHERE user_id = {userId};", connection);
             await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        private DateTime GetLatestScrobbleDate(List<LastTrack> newScrobbles)
+        {
+            if (!newScrobbles.Any(a => a.TimePlayed.HasValue))
+            {
+                Console.WriteLine("No recent scrobble date in update!");
+                return DateTime.UtcNow;
+            }
+
+            return newScrobbles.First(f => f.TimePlayed.HasValue).TimePlayed.Value.DateTime;
         }
     }
 }

--- a/src/FMBot.LastFM/Services/GlobalUpdateService.cs
+++ b/src/FMBot.LastFM/Services/GlobalUpdateService.cs
@@ -33,7 +33,7 @@ namespace FMBot.LastFM.Services
         }
 
 
-        public async Task UpdateUser(User user)
+        public async Task<int> UpdateUser(User user)
         {
             Thread.Sleep(1000);
 
@@ -42,7 +42,7 @@ namespace FMBot.LastFM.Services
             var recentTracks = await this._lastFMClient.User.GetRecentScrobbles(user.UserNameLastFM, count: 1000);
             if (!recentTracks.Success || !recentTracks.Content.Any())
             {
-                return;
+                return 0;
             }
 
             var newScrobbles = recentTracks.Content
@@ -52,7 +52,7 @@ namespace FMBot.LastFM.Services
             if (!newScrobbles.Any())
             {
                 Console.WriteLine($"No new scrobbles for {user.UserNameLastFM}");
-                return;
+                return 0;
             }
 
             await UpdateArtistsForUser(user, newScrobbles);
@@ -63,6 +63,8 @@ namespace FMBot.LastFM.Services
 
             var latestScrobbleDate = recentTracks.Content.OrderByDescending(o => o.TimePlayed.Value.DateTime).First().TimePlayed.Value.DateTime;
             await SetUserUpdateTime(user.UserId, DateTime.UtcNow, latestScrobbleDate);
+
+            return newScrobbles.Count;
         }
 
         private async Task UpdateArtistsForUser(User user, IEnumerable<LastTrack> newScrobbles)

--- a/src/FMBot.LastFM/Services/LastFMService.cs
+++ b/src/FMBot.LastFM/Services/LastFMService.cs
@@ -252,6 +252,7 @@ namespace FMBot.LastFM.Services
                         queryParams.Add("page", (i + 1).ToString());
 
                         var pageResponse = await this._lastfmApi.CallApiAsync<TopTracksResponse>(queryParams, Call.TopTracks);
+                        Statistics.LastfmApiCalls.Inc();
 
                         if (pageResponse.Success)
                         {

--- a/src/FMBot.LastFM/Services/UpdateService.cs
+++ b/src/FMBot.LastFM/Services/UpdateService.cs
@@ -4,9 +4,11 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FMBot.Persistence.Domain.Models;
+using FMBot.Persistence.EntityFrameWork;
 using IF.Lastfm.Core.Api;
 using IF.Lastfm.Core.Api.Enums;
 using IF.Lastfm.Core.Objects;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Npgsql;
 using PostgreSQLCopyHelper;
@@ -22,27 +24,42 @@ namespace FMBot.LastFM.Services
 
         private readonly string _connectionString;
 
-        public UpdateService(IConfigurationRoot configuration)
+        private readonly LastFMService lastFmService;
+
+        public UpdateService(
+            IConfigurationRoot configuration,
+            LastFMService lastFmService)
         {
+            this.lastFmService = lastFmService;
             this._key = configuration.GetSection("LastFm:Key").Value;
             this._secret = configuration.GetSection("LastFm:Secret").Value;
             this._connectionString = configuration.GetSection("Database:ConnectionString").Value;
             this._lastFMClient = new LastfmClient(this._key, this._secret);
         }
 
-        public async Task InitialUserIndex(User user)
+        public async Task IndexUser(User user)
         {
-            Thread.Sleep(1000);
+            Thread.Sleep(5000);
 
             Console.WriteLine($"Starting artist store for {user.UserNameLastFM}");
+            var now = DateTime.UtcNow;
 
-            var artists = await GetArtistForUserFromLastFm(user);
+            var artists = await GetArtistsForUserFromLastFm(user);
+            await InsertArtistsIntoDatabase(artists, user.UserId, now);
 
-            await InsertArtistsIntoDatabase(artists, user.UserId, DateTime.UtcNow);
+            var albums = await GetAlbumsForUserFromLastFm(user);
+            await InsertAlbumsIntoDatabase(albums, user.UserId, now);
+
+            var tracks = await GetTracksForUserFromLastFm(user);
+            await InsertTracksIntoDatabase(tracks, user.UserId, now);
+
+            await SetUserIndexTime(user.UserId, now);
         }
 
-        private async Task<IReadOnlyList<UserArtist>> GetArtistForUserFromLastFm(User user)
+        private async Task<IReadOnlyList<UserArtist>> GetArtistsForUserFromLastFm(User user)
         {
+            Console.WriteLine($"Getting artists for user {user.UserNameLastFM}");
+
             var topArtists = new List<LastArtist>();
 
             const int amountOfApiCalls = 4000 / 1000;
@@ -73,8 +90,66 @@ namespace FMBot.LastFM.Services
             }).ToList();
         }
 
+        private async Task<IReadOnlyList<UserAlbum>> GetAlbumsForUserFromLastFm(User user)
+        {
+            Console.WriteLine($"Getting albums for user {user.UserNameLastFM}");
+
+            var topAlbums = new List<LastAlbum>();
+
+            const int amountOfApiCalls = 4000 / 1000;
+            for (var i = 1; i < amountOfApiCalls + 1; i++)
+            {
+                var albumResult = await this._lastFMClient.User.GetTopAlbums(user.UserNameLastFM,
+                    LastStatsTimeSpan.Overall, i, 1000);
+
+                topAlbums.AddRange(albumResult);
+
+                if (albumResult.Count() < 1000)
+                {
+                    break;
+                }
+            }
+
+            if (topAlbums.Count == 0)
+            {
+                return new List<UserAlbum>();
+            }
+
+            return topAlbums.Select(a => new UserAlbum
+            {
+                LastUpdated = DateTime.UtcNow,
+                Name = a.Name,
+                ArtistName = a.ArtistName,
+                Playcount = a.PlayCount.Value,
+                UserId = user.UserId
+            }).ToList();
+        }
+
+        private async Task<IReadOnlyList<UserTrack>> GetTracksForUserFromLastFm(User user)
+        {
+            Console.WriteLine($"Getting tracks for user {user.UserNameLastFM}");
+
+            var trackResult = await this.lastFmService.GetTopTracksAsync(user.UserNameLastFM, "overall", 1000, 5);
+
+            if (!trackResult.Success || trackResult.Content.TopTracks.Track.Count == 0)
+            {
+                return new List<UserTrack>();
+            }
+
+            return trackResult.Content.TopTracks.Track.Select(a => new UserTrack
+            {
+                LastUpdated = DateTime.UtcNow,
+                Name = a.Name,
+                ArtistName = a.Artist.Name,
+                Playcount = Convert.ToInt32(a.Playcount),
+                UserId = user.UserId
+            }).ToList();
+        }
+
         private async Task InsertArtistsIntoDatabase(IReadOnlyList<UserArtist> artists, int userId, DateTime now)
         {
+            Console.WriteLine($"Inserting artists for user {userId}");
+
             var copyHelper = new PostgreSQLCopyHelper<UserArtist>("public", "user_artists")
                 .MapText("name", x => x.Name)
                 .MapInteger("user_id", x => x.UserId)
@@ -88,9 +163,168 @@ namespace FMBot.LastFM.Services
             await deleteCurrentArtists.ExecuteNonQueryAsync().ConfigureAwait(false);
 
             await copyHelper.SaveAllAsync(connection, artists).ConfigureAwait(false);
+        }
 
-            await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_indexed='{now:u}' WHERE user_id = {userId};", connection);
+        private async Task InsertAlbumsIntoDatabase(IReadOnlyList<UserAlbum> albums, int userId, DateTime now)
+        {
+            Console.WriteLine($"Inserting albums for user {userId}");
+
+            var copyHelper = new PostgreSQLCopyHelper<UserAlbum>("public", "user_albums")
+                .MapText("name", x => x.Name)
+                .MapText("artist_name", x => x.ArtistName)
+                .MapInteger("user_id", x => x.UserId)
+                .MapInteger("playcount", x => x.Playcount)
+                .MapTimeStamp("last_updated", x => x.LastUpdated);
+
+            await using var connection = new NpgsqlConnection(this._connectionString);
+            connection.Open();
+
+            await using var deleteCurrentAlbums = new NpgsqlCommand($"DELETE FROM public.user_albums WHERE user_id = {userId};", connection);
+            await deleteCurrentAlbums.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+            await copyHelper.SaveAllAsync(connection, albums).ConfigureAwait(false);
+        }
+
+        private async Task InsertTracksIntoDatabase(IReadOnlyList<UserTrack> artists, int userId, DateTime now)
+        {
+            Console.WriteLine($"Inserting tracks for user {userId}");
+
+            var copyHelper = new PostgreSQLCopyHelper<UserTrack>("public", "user_tracks")
+                .MapText("name", x => x.Name)
+                .MapText("artist_name", x => x.ArtistName)
+                .MapInteger("user_id", x => x.UserId)
+                .MapInteger("playcount", x => x.Playcount)
+                .MapTimeStamp("last_updated", x => x.LastUpdated);
+
+            await using var connection = new NpgsqlConnection(this._connectionString);
+            connection.Open();
+
+            await using var deleteCurrentTracks = new NpgsqlCommand($"DELETE FROM public.user_tracks WHERE user_id = {userId};", connection);
+            await deleteCurrentTracks.ExecuteNonQueryAsync().ConfigureAwait(false);
+
+            await copyHelper.SaveAllAsync(connection, artists).ConfigureAwait(false);
+
+        }
+
+        private async Task SetUserIndexTime(int userId, DateTime now)
+        {
+            await using var connection = new NpgsqlConnection(this._connectionString);
+            connection.Open();
+
+            await using var setIndexTime = new NpgsqlCommand($"UPDATE public.users SET last_indexed='{now:u}', last_scrobble_update = '{now:u}' WHERE user_id = {userId};", connection);
             await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+        }
+
+        public async Task UpdateUser(User user)
+        {
+            Thread.Sleep(1000);
+
+            Console.WriteLine($"Updating {user.UserNameLastFM}");
+
+            var recentTracks = await this._lastFMClient.User.GetRecentScrobbles(user.UserNameLastFM, count: 1000);
+            if (!recentTracks.Success || !recentTracks.Content.Any())
+            {
+                return;
+            }
+
+            var newScrobbles = recentTracks.Content
+                .Where(w => w.TimePlayed.Value.DateTime > user.LastScrobbleUpdate)
+                .ToList();
+
+            if (!newScrobbles.Any())
+            {
+                Console.WriteLine($"No new scrobbles for {user.UserNameLastFM}");
+                return;
+            }
+
+            await UpdateArtistsForUser(user, newScrobbles);
+
+            await UpdateAlbumsForUser(user, newScrobbles);
+
+            await UpdateTracksForUser(user, newScrobbles);
+        }
+
+
+        private async Task UpdateArtistsForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var artist in newScrobbles.GroupBy(g => g.ArtistName))
+            {
+                var correctedArtist = await db.Artists.FirstOrDefaultAsync(f =>
+                        f.Name.ToLower() == artist.Key.ToLower() ||
+                        f.Aliases.Select(s => s.ToLower()).Contains(artist.Key.ToLower());
+
+
+                var artistName = correctedArtist != null ? correctedArtist.Name : artist.Key;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var updateArtistPlaycount = new NpgsqlCommand($"UPDATE public.user_artists SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name);", connection);
+
+                updateArtistPlaycount.Parameters.AddWithValue("playcountToAdd", artist.Count());
+                updateArtistPlaycount.Parameters.AddWithValue("userId", user.UserId);
+                updateArtistPlaycount.Parameters.AddWithValue("name", artistName);
+
+                await updateArtistPlaycount.ExecuteNonQueryAsync().ConfigureAwait(false);
+                Console.WriteLine($"Adding {artist.Count()} plays to {artistName} for {user.UserNameLastFM}");
+            }
+
+            Console.WriteLine($"Updated artists for {user.UserNameLastFM}");
+        }
+
+        private async Task UpdateAlbumsForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var album in newScrobbles.GroupBy(x => new { x.ArtistName, x.AlbumName }))
+            {
+                var correctedArtist = await db.Artists.FirstOrDefaultAsync(f =>
+                    f.Name.ToLower() == album.Key.ArtistName.ToLower() ||
+                    f.Aliases.Select(s => s.ToLower()).Contains(album.Key.ArtistName.ToLower()));
+
+                var artistName = correctedArtist != null ? correctedArtist.Name : album.Key.ArtistName;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var setIndexTime = new NpgsqlCommand($"UPDATE public.user_albums SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name) AND UPPER(artist_name) = UPPER(@artistName) ;", connection);
+
+                setIndexTime.Parameters.AddWithValue("playcountToAdd", album.Count());
+                setIndexTime.Parameters.AddWithValue("userId", user.UserId);
+                setIndexTime.Parameters.AddWithValue("name", album.Key.AlbumName);
+                setIndexTime.Parameters.AddWithValue("artistName", artistName);
+
+                await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            Console.WriteLine($"Updated albums for {user.UserNameLastFM}");
+        }
+
+        private async Task UpdateTracksForUser(User user, IEnumerable<LastTrack> newScrobbles)
+        {
+            await using var db = new FMBotDbContext(this._connectionString);
+            foreach (var track in newScrobbles.GroupBy(x => new { x.ArtistName, x.Name }))
+            {
+                var correctedArtist = await db.Artists.FirstOrDefaultAsync(f =>
+                    f.Name.ToLower() == track.Key.ArtistName.ToLower() ||
+                    f.Aliases.Select(s => s.ToLower()).Contains(track.Key.ArtistName.ToLower()));
+
+                var artistName = correctedArtist != null ? correctedArtist.Name : track.Key.ArtistName;
+
+                await using var connection = new NpgsqlConnection(this._connectionString);
+                connection.Open();
+
+                await using var setIndexTime = new NpgsqlCommand($"UPDATE public.user_artists SET playcount = playcount + @playcountToAdd WHERE user_id = @userId AND UPPER(name) = UPPER(@name) AND UPPER(artist_name) = UPPER(@artistName);", connection);
+
+                setIndexTime.Parameters.AddWithValue("playcountToAdd", track.Count());
+                setIndexTime.Parameters.AddWithValue("userId", user.UserId);
+                setIndexTime.Parameters.AddWithValue("name", track.Key.Name);
+                setIndexTime.Parameters.AddWithValue("artistName", artistName);
+
+                await setIndexTime.ExecuteNonQueryAsync().ConfigureAwait(false);
+            }
+
+            Console.WriteLine($"Updated tracks for {user.UserNameLastFM}");
         }
     }
 }

--- a/src/FMBot.Logger/Logger.cs
+++ b/src/FMBot.Logger/Logger.cs
@@ -20,11 +20,6 @@ namespace FMBot.Logger
             sw.WriteLine($"{DateTime.Now:T} : {text}");
         }
 
-        public void LogCommandUsed(ulong? id, ulong channelId, ulong userId, string commandName)
-        {
-            Log($"GuildId: {id} || ChannelId: {channelId} || UserId: {userId} || Used: {commandName}");
-        }
-
         public void LogError(string errorReason, string message = null, string username = null, string guildName = null, ulong? guildId = null)
         {
             string error = $"{DateTime.Now:T} : Error - {errorReason} \n" +

--- a/src/FMBot.Persistence.Domain/Models/Album.cs
+++ b/src/FMBot.Persistence.Domain/Models/Album.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 
 namespace FMBot.Persistence.Domain.Models
 {
-    public class Artist
+    public class Album
     {
         public int Id { get; set; }
 
         public string Name { get; set; }
+
+        public string ArtistName { get; set; }
 
         public string LastFmUrl { get; set; }
 
@@ -21,12 +23,14 @@ namespace FMBot.Persistence.Domain.Models
 
         public int? Popularity { get; set; }
 
-        public string[] Aliases { get; set; }
+        public string Label { get; set; }
 
-        public string[] Genres { get; set; }
+        public DateTime? ReleaseDate { get; set; }
+
+        public int ArtistId { get; set; }
+
+        public Artist Artist { get; set; }
 
         public ICollection<Track> Tracks { get; set; }
-
-        public ICollection<Album> Albums { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/Artist.cs
+++ b/src/FMBot.Persistence.Domain/Models/Artist.cs
@@ -23,10 +23,12 @@ namespace FMBot.Persistence.Domain.Models
 
         public string[] Aliases { get; set; }
 
-        public string[] Genres { get; set; }
-
         public ICollection<Track> Tracks { get; set; }
 
         public ICollection<Album> Albums { get; set; }
+
+        public ICollection<ArtistAlias> ArtistAliases { get; set; }
+
+        public ICollection<ArtistGenre> ArtistGenres { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/ArtistAlias.cs
+++ b/src/FMBot.Persistence.Domain/Models/ArtistAlias.cs
@@ -1,0 +1,15 @@
+namespace FMBot.Persistence.Domain.Models
+{
+    public class ArtistAlias
+    {
+        public int Id { get; set; }
+
+        public int ArtistId { get; set; }
+
+        public string Alias { get; set; }
+
+        public bool CorrectsInScrobbles { get; set; }
+
+        public Artist Artist { get; set; }
+    }
+}

--- a/src/FMBot.Persistence.Domain/Models/ArtistGenre.cs
+++ b/src/FMBot.Persistence.Domain/Models/ArtistGenre.cs
@@ -1,0 +1,13 @@
+namespace FMBot.Persistence.Domain.Models
+{
+    public class ArtistGenre
+    {
+        public int Id { get; set; }
+
+        public int ArtistId { get; set; }
+
+        public string Name { get; set; }
+
+        public Artist Artist { get; set; }
+    }
+}

--- a/src/FMBot.Persistence.Domain/Models/Guilds.cs
+++ b/src/FMBot.Persistence.Domain/Models/Guilds.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using FMBot.Domain.Models;
 
 namespace FMBot.Persistence.Domain.Models
 {

--- a/src/FMBot.Persistence.Domain/Models/Track.cs
+++ b/src/FMBot.Persistence.Domain/Models/Track.cs
@@ -18,6 +18,8 @@ namespace FMBot.Persistence.Domain.Models
 
         public int? Key { get; set; }
 
+        public int? Popularity { get; set; }
+
         public float? Tempo { get; set; }
 
         public int? DurationMs { get; set; }

--- a/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace FMBot.Persistence.Domain.Models
+{
+    public class UserAlbum
+    {
+        public int UserAlbumId { get; set; }
+
+        public int UserId { get; set; }
+
+        public string Name { get; set; }
+
+        public int Playcount { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+
+        public User User { get; set; }
+    }
+}

--- a/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
@@ -10,6 +10,8 @@ namespace FMBot.Persistence.Domain.Models
 
         public string Name { get; set; }
 
+        public string ArtistName { get; set; }
+
         public int Playcount { get; set; }
 
         public DateTime LastUpdated { get; set; }

--- a/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserAlbum.cs
@@ -14,8 +14,6 @@ namespace FMBot.Persistence.Domain.Models
 
         public int Playcount { get; set; }
 
-        public DateTime LastUpdated { get; set; }
-
         public User User { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/UserArtists.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserArtists.cs
@@ -4,7 +4,7 @@ namespace FMBot.Persistence.Domain.Models
 {
     public class UserArtist
     {
-        public int UserArtistId { get; set; }
+        public int ArtistId { get; set; }
 
         public int UserId { get; set; }
 

--- a/src/FMBot.Persistence.Domain/Models/UserArtists.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserArtists.cs
@@ -4,7 +4,7 @@ namespace FMBot.Persistence.Domain.Models
 {
     public class UserArtist
     {
-        public int ArtistId { get; set; }
+        public int UserArtistId { get; set; }
 
         public int UserId { get; set; }
 

--- a/src/FMBot.Persistence.Domain/Models/UserArtists.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserArtists.cs
@@ -12,8 +12,6 @@ namespace FMBot.Persistence.Domain.Models
 
         public int Playcount { get; set; }
 
-        public DateTime LastUpdated { get; set; }
-
         public User User { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/UserTrack.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserTrack.cs
@@ -14,8 +14,6 @@ namespace FMBot.Persistence.Domain.Models
 
         public int Playcount { get; set; }
 
-        public DateTime LastUpdated { get; set; }
-
         public User User { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/UserTrack.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserTrack.cs
@@ -4,11 +4,9 @@ namespace FMBot.Persistence.Domain.Models
 {
     public class UserTrack
     {
-        public int UserAlbumId { get; set; }
+        public int UserTrackId { get; set; }
 
         public int UserId { get; set; }
-
-        public int TrackId { get; set; }
 
         public string Name { get; set; }
 
@@ -19,7 +17,5 @@ namespace FMBot.Persistence.Domain.Models
         public DateTime LastUpdated { get; set; }
 
         public User User { get; set; }
-
-        public Track Track { get; set; }
     }
 }

--- a/src/FMBot.Persistence.Domain/Models/UserTrack.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserTrack.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace FMBot.Persistence.Domain.Models
+{
+    public class UserTrack
+    {
+        public int UserAlbumId { get; set; }
+
+        public int UserId { get; set; }
+
+        public int TrackId { get; set; }
+
+        public string Name { get; set; }
+
+        public string ArtistName { get; set; }
+
+        public int Playcount { get; set; }
+
+        public DateTime LastUpdated { get; set; }
+
+        public User User { get; set; }
+
+        public Track Track { get; set; }
+    }
+}

--- a/src/FMBot.Persistence.Domain/Models/Users.cs
+++ b/src/FMBot.Persistence.Domain/Models/Users.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using FMBot.Domain.Models;
 
 namespace FMBot.Persistence.Domain.Models
 {
@@ -32,6 +33,8 @@ namespace FMBot.Persistence.Domain.Models
         public DateTime? LastIndexed { get; set; }
 
         public DateTime? LastUpdated { get; set; }
+
+        public DateTime? LastScrobbleUpdate { get; set; }
 
         public ICollection<Friend> FriendedByUsers { get; set; }
 

--- a/src/FMBot.Persistence.Domain/Models/Users.cs
+++ b/src/FMBot.Persistence.Domain/Models/Users.cs
@@ -31,11 +31,17 @@ namespace FMBot.Persistence.Domain.Models
 
         public DateTime? LastIndexed { get; set; }
 
+        public DateTime? LastUpdated { get; set; }
+
         public ICollection<Friend> FriendedByUsers { get; set; }
 
         public ICollection<Friend> Friends { get; set; }
 
         public ICollection<UserArtist> Artists { get; set; }
+
+        public ICollection<UserAlbum> Albums { get; set; }
+
+        public ICollection<UserTrack> Tracks { get; set; }
 
         public ICollection<GuildUser> GuildUsers { get; set; }
     }

--- a/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -12,15 +12,15 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="5.0.0-preview5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.8.20407.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0-preview.8.20407.4">
+    <PackageReference Include="EFCore.NamingConventions" Version="1.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-preview.8.20407.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0-preview8" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FMBot.Persistence.Domain\FMBot.Persistence.Domain.csproj" />

--- a/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
@@ -12,15 +12,15 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
+    <PackageReference Include="EFCore.NamingConventions" Version="5.0.0-preview5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.0-preview.8.20407.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.0-preview.8.20407.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0-preview.8.20407.4" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.0-preview8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FMBot.Persistence.Domain\FMBot.Persistence.Domain.csproj" />

--- a/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBot.Persistence.EntityFrameWork.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.7" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
   </ItemGroup>

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -36,13 +36,17 @@ namespace FMBot.Persistence.EntityFrameWork
         public virtual DbSet<Album> Albums { get; set; }
         public virtual DbSet<Track> Tracks { get; set; }
 
+        public virtual DbSet<ArtistGenre> ArtistGenres { get; set; }
+        public virtual DbSet<ArtistAlias> ArtistAliases { get; set; }
+
+
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
             if (!optionsBuilder.IsConfigured)
             {
                 // When creating migrations, make sure to enter the connection string below.
                 optionsBuilder.UseNpgsql(string.IsNullOrEmpty(this._connectionString)
-                    ? "Host=localhost;Port=5433;Username=postgres;Password=password;Database=fmbot;Command Timeout=15;Timeout=30;Persist Security Info=True"
+                    ? "Host=localhost;Port=5433;Username=postgres;Password=password;Database=fmbot;Command Timeout=120;Timeout=120;Persist Security Info=True"
                     : this._connectionString);
 
                 optionsBuilder.UseSnakeCaseNamingConvention();
@@ -138,11 +142,6 @@ namespace FMBot.Persistence.EntityFrameWork
                     .HasConversion(
                         v => string.Join(',', v),
                         v => v.Split(',', StringSplitOptions.RemoveEmptyEntries));
-
-                entity.Property(e => e.Genres)
-                    .HasConversion(
-                        v => string.Join(',', v),
-                        v => v.Split(',', StringSplitOptions.RemoveEmptyEntries));
             });
 
 
@@ -161,6 +160,24 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(d => d.Artist)
                     .WithMany(p => p.Tracks)
+                    .HasForeignKey(d => d.ArtistId);
+            });
+
+            modelBuilder.Entity<ArtistAlias>(entity =>
+            {
+                entity.HasKey(a => a.Id);
+
+                entity.HasOne(d => d.Artist)
+                    .WithMany(p => p.ArtistAliases)
+                    .HasForeignKey(d => d.ArtistId);
+            });
+
+            modelBuilder.Entity<ArtistGenre>(entity =>
+            {
+                entity.HasKey(a => a.Id);
+
+                entity.HasOne(d => d.Artist)
+                    .WithMany(p => p.ArtistGenres)
                     .HasForeignKey(d => d.ArtistId);
             });
         }

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -46,7 +46,7 @@ namespace FMBot.Persistence.EntityFrameWork
             {
                 // When creating migrations, make sure to enter the connection string below.
                 optionsBuilder.UseNpgsql(string.IsNullOrEmpty(this._connectionString)
-                    ? "Host=localhost;Port=5433;Username=postgres;Password=password;Database=fmbot;Command Timeout=120;Timeout=120;Persist Security Info=True"
+                    ? "Host=localhost;Port=5433;Username=postgres;Password=password;Database=fmbot;Command Timeout=360;Timeout=360;Persist Security Info=True"
                     : this._connectionString);
 
                 optionsBuilder.UseSnakeCaseNamingConvention();
@@ -109,7 +109,7 @@ namespace FMBot.Persistence.EntityFrameWork
 
             modelBuilder.Entity<UserArtist>(entity =>
             {
-                entity.HasKey(a => a.UserArtistId);
+                entity.HasKey(a => a.ArtistId);
 
                 entity.HasOne(u => u.User)
                     .WithMany(a => a.Artists)

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -27,9 +27,13 @@ namespace FMBot.Persistence.EntityFrameWork
         public virtual DbSet<Guild> Guilds { get; set; }
         public virtual DbSet<GuildUser> GuildUsers { get; set; }
         public virtual DbSet<User> Users { get; set; }
+
         public virtual DbSet<UserArtist> UserArtists { get; set; }
+        public virtual DbSet<UserAlbum> UserAlbums { get; set; }
+        public virtual DbSet<UserTrack> UserTracks { get; set; }
 
         public virtual DbSet<Artist> Artists { get; set; }
+        public virtual DbSet<Album> Albums { get; set; }
         public virtual DbSet<Track> Tracks { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -101,10 +105,28 @@ namespace FMBot.Persistence.EntityFrameWork
 
             modelBuilder.Entity<UserArtist>(entity =>
             {
-                entity.HasKey(a => a.ArtistId);
+                entity.HasKey(a => a.UserArtistId);
 
                 entity.HasOne(u => u.User)
                     .WithMany(a => a.Artists)
+                    .HasForeignKey(f => f.UserId);
+            });
+
+            modelBuilder.Entity<UserAlbum>(entity =>
+            {
+                entity.HasKey(a => a.UserAlbumId);
+
+                entity.HasOne(u => u.User)
+                    .WithMany(a => a.Albums)
+                    .HasForeignKey(f => f.UserId);
+            });
+
+            modelBuilder.Entity<UserTrack>(entity =>
+            {
+                entity.HasKey(a => a.UserTrackId);
+
+                entity.HasOne(u => u.User)
+                    .WithMany(a => a.Tracks)
                     .HasForeignKey(f => f.UserId);
             });
 
@@ -116,6 +138,21 @@ namespace FMBot.Persistence.EntityFrameWork
                     .HasConversion(
                         v => string.Join(',', v),
                         v => v.Split(',', StringSplitOptions.RemoveEmptyEntries));
+
+                entity.Property(e => e.Genres)
+                    .HasConversion(
+                        v => string.Join(',', v),
+                        v => v.Split(',', StringSplitOptions.RemoveEmptyEntries));
+            });
+
+
+            modelBuilder.Entity<Album>(entity =>
+            {
+                entity.HasKey(a => a.Id);
+
+                entity.HasOne(d => d.Artist)
+                    .WithMany(p => p.Albums)
+                    .HasForeignKey(d => d.ArtistId);
             });
 
             modelBuilder.Entity<Track>(entity =>

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -113,7 +113,8 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(u => u.User)
                     .WithMany(a => a.Artists)
-                    .HasForeignKey(f => f.UserId);
+                    .HasForeignKey(f => f.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<UserAlbum>(entity =>
@@ -122,7 +123,8 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(u => u.User)
                     .WithMany(a => a.Albums)
-                    .HasForeignKey(f => f.UserId);
+                    .HasForeignKey(f => f.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<UserTrack>(entity =>
@@ -131,7 +133,8 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(u => u.User)
                     .WithMany(a => a.Tracks)
-                    .HasForeignKey(f => f.UserId);
+                    .HasForeignKey(f => f.UserId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<Artist>(entity =>
@@ -169,7 +172,8 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(d => d.Artist)
                     .WithMany(p => p.ArtistAliases)
-                    .HasForeignKey(d => d.ArtistId);
+                    .HasForeignKey(d => d.ArtistId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
 
             modelBuilder.Entity<ArtistGenre>(entity =>
@@ -178,7 +182,8 @@ namespace FMBot.Persistence.EntityFrameWork
 
                 entity.HasOne(d => d.Artist)
                     .WithMany(p => p.ArtistGenres)
-                    .HasForeignKey(d => d.ArtistId);
+                    .HasForeignKey(d => d.ArtistId)
+                    .OnDelete(DeleteBehavior.Cascade);
             });
         }
     }

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202302_AddUserAlbumsAndTracks.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202302_AddUserAlbumsAndTracks.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200819202302_AddUserAlbumsAndTracks")]
+    partial class AddUserAlbumsAndTracks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -72,12 +74,12 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id")
-                        .HasName("pk_albums");
+                        .HasName("pk_album");
 
                     b.HasIndex("ArtistId")
-                        .HasName("ix_albums_artist_id");
+                        .HasName("ix_album_artist_id");
 
-                    b.ToTable("albums");
+                    b.ToTable("album");
                 });
 
             modelBuilder.Entity("FMBot.Persistence.Domain.Models.Artist", b =>
@@ -398,12 +400,12 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                         .HasColumnType("integer");
 
                     b.HasKey("UserAlbumId")
-                        .HasName("pk_user_albums");
+                        .HasName("pk_user_album");
 
                     b.HasIndex("UserId")
-                        .HasName("ix_user_albums_user_id");
+                        .HasName("ix_user_album_user_id");
 
-                    b.ToTable("user_albums");
+                    b.ToTable("user_album");
                 });
 
             modelBuilder.Entity("FMBot.Persistence.Domain.Models.UserArtist", b =>
@@ -468,12 +470,12 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                         .HasColumnType("integer");
 
                     b.HasKey("UserTrackId")
-                        .HasName("pk_user_tracks");
+                        .HasName("pk_user_track");
 
                     b.HasIndex("UserId")
-                        .HasName("ix_user_tracks_user_id");
+                        .HasName("ix_user_track_user_id");
 
-                    b.ToTable("user_tracks");
+                    b.ToTable("user_track");
                 });
 
             modelBuilder.Entity("FMBot.Persistence.Domain.Models.Album", b =>
@@ -481,7 +483,7 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                     b.HasOne("FMBot.Persistence.Domain.Models.Artist", "Artist")
                         .WithMany("Albums")
                         .HasForeignKey("ArtistId")
-                        .HasConstraintName("fk_albums_artists_artist_id")
+                        .HasConstraintName("fk_album_artists_artist_id")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -523,7 +525,7 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                     b.HasOne("FMBot.Persistence.Domain.Models.Album", null)
                         .WithMany("Tracks")
                         .HasForeignKey("AlbumId")
-                        .HasConstraintName("fk_tracks_albums_album_id");
+                        .HasConstraintName("fk_tracks_album_album_id");
 
                     b.HasOne("FMBot.Persistence.Domain.Models.Artist", "Artist")
                         .WithMany("Tracks")
@@ -536,7 +538,7 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                     b.HasOne("FMBot.Persistence.Domain.Models.User", "User")
                         .WithMany("Albums")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("fk_user_albums_users_user_id")
+                        .HasConstraintName("fk_user_album_users_user_id")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
@@ -556,7 +558,7 @@ namespace FMBot.Persistence.EntityFrameWork.Migrations
                     b.HasOne("FMBot.Persistence.Domain.Models.User", "User")
                         .WithMany("Tracks")
                         .HasForeignKey("UserId")
-                        .HasConstraintName("fk_user_tracks_users_user_id")
+                        .HasConstraintName("fk_user_track_users_user_id")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202302_AddUserAlbumsAndTracks.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202302_AddUserAlbumsAndTracks.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class AddUserAlbumsAndTracks : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists");
+
+            migrationBuilder.DropColumn(
+                name: "artist_id",
+                table: "user_artists");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_updated",
+                table: "users",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "user_artist_id",
+                table: "user_artists",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddColumn<int>(
+                name: "album_id",
+                table: "tracks",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "popularity",
+                table: "tracks",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "genres",
+                table: "artists",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "popularity",
+                table: "artists",
+                nullable: true);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists",
+                column: "user_artist_id");
+
+            migrationBuilder.CreateTable(
+                name: "album",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    name = table.Column<string>(nullable: true),
+                    artist_name = table.Column<string>(nullable: true),
+                    last_fm_url = table.Column<string>(nullable: true),
+                    mbid = table.Column<Guid>(nullable: true),
+                    spotify_image_url = table.Column<string>(nullable: true),
+                    spotify_image_date = table.Column<DateTime>(nullable: true),
+                    spotify_id = table.Column<string>(nullable: true),
+                    popularity = table.Column<int>(nullable: true),
+                    label = table.Column<string>(nullable: true),
+                    release_date = table.Column<DateTime>(nullable: true),
+                    artist_id = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_album", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_album_artists_artist_id",
+                        column: x => x.artist_id,
+                        principalTable: "artists",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_album",
+                columns: table => new
+                {
+                    user_album_id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    user_id = table.Column<int>(nullable: false),
+                    name = table.Column<string>(nullable: true),
+                    artist_name = table.Column<string>(nullable: true),
+                    playcount = table.Column<int>(nullable: false),
+                    last_updated = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_album", x => x.user_album_id);
+                    table.ForeignKey(
+                        name: "fk_user_album_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "user_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "user_track",
+                columns: table => new
+                {
+                    user_track_id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    user_id = table.Column<int>(nullable: false),
+                    name = table.Column<string>(nullable: true),
+                    artist_name = table.Column<string>(nullable: true),
+                    playcount = table.Column<int>(nullable: false),
+                    last_updated = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_user_track", x => x.user_track_id);
+                    table.ForeignKey(
+                        name: "fk_user_track_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "user_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_tracks_album_id",
+                table: "tracks",
+                column: "album_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_album_artist_id",
+                table: "album",
+                column: "artist_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_album_user_id",
+                table: "user_album",
+                column: "user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_track_user_id",
+                table: "user_track",
+                column: "user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_tracks_album_album_id",
+                table: "tracks",
+                column: "album_id",
+                principalTable: "album",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_tracks_album_album_id",
+                table: "tracks");
+
+            migrationBuilder.DropTable(
+                name: "album");
+
+            migrationBuilder.DropTable(
+                name: "user_album");
+
+            migrationBuilder.DropTable(
+                name: "user_track");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists");
+
+            migrationBuilder.DropIndex(
+                name: "ix_tracks_album_id",
+                table: "tracks");
+
+            migrationBuilder.DropColumn(
+                name: "last_updated",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "user_artist_id",
+                table: "user_artists");
+
+            migrationBuilder.DropColumn(
+                name: "album_id",
+                table: "tracks");
+
+            migrationBuilder.DropColumn(
+                name: "popularity",
+                table: "tracks");
+
+            migrationBuilder.DropColumn(
+                name: "genres",
+                table: "artists");
+
+            migrationBuilder.DropColumn(
+                name: "popularity",
+                table: "artists");
+
+            migrationBuilder.AddColumn<int>(
+                name: "artist_id",
+                table: "user_artists",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists",
+                column: "artist_id");
+        }
+    }
+}

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202748_AddAlbums.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202748_AddAlbums.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200819202748_AddAlbums")]
+    partial class AddAlbums
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202748_AddAlbums.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200819202748_AddAlbums.cs
@@ -1,0 +1,217 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class AddAlbums : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_album_artists_artist_id",
+                table: "album");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_tracks_album_album_id",
+                table: "tracks");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_user_album_users_user_id",
+                table: "user_album");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_user_track_users_user_id",
+                table: "user_track");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_track",
+                table: "user_track");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_album",
+                table: "user_album");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_album",
+                table: "album");
+
+            migrationBuilder.RenameTable(
+                name: "user_track",
+                newName: "user_tracks");
+
+            migrationBuilder.RenameTable(
+                name: "user_album",
+                newName: "user_albums");
+
+            migrationBuilder.RenameTable(
+                name: "album",
+                newName: "albums");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_user_track_user_id",
+                table: "user_tracks",
+                newName: "ix_user_tracks_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_user_album_user_id",
+                table: "user_albums",
+                newName: "ix_user_albums_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_album_artist_id",
+                table: "albums",
+                newName: "ix_albums_artist_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_tracks",
+                table: "user_tracks",
+                column: "user_track_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_albums",
+                table: "user_albums",
+                column: "user_album_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_albums",
+                table: "albums",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_albums_artists_artist_id",
+                table: "albums",
+                column: "artist_id",
+                principalTable: "artists",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_tracks_albums_album_id",
+                table: "tracks",
+                column: "album_id",
+                principalTable: "albums",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_user_albums_users_user_id",
+                table: "user_albums",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_user_tracks_users_user_id",
+                table: "user_tracks",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_albums_artists_artist_id",
+                table: "albums");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_tracks_albums_album_id",
+                table: "tracks");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_user_albums_users_user_id",
+                table: "user_albums");
+
+            migrationBuilder.DropForeignKey(
+                name: "fk_user_tracks_users_user_id",
+                table: "user_tracks");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_tracks",
+                table: "user_tracks");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_albums",
+                table: "user_albums");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_albums",
+                table: "albums");
+
+            migrationBuilder.RenameTable(
+                name: "user_tracks",
+                newName: "user_track");
+
+            migrationBuilder.RenameTable(
+                name: "user_albums",
+                newName: "user_album");
+
+            migrationBuilder.RenameTable(
+                name: "albums",
+                newName: "album");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_user_tracks_user_id",
+                table: "user_track",
+                newName: "ix_user_track_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_user_albums_user_id",
+                table: "user_album",
+                newName: "ix_user_album_user_id");
+
+            migrationBuilder.RenameIndex(
+                name: "ix_albums_artist_id",
+                table: "album",
+                newName: "ix_album_artist_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_track",
+                table: "user_track",
+                column: "user_track_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_album",
+                table: "user_album",
+                column: "user_album_id");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_album",
+                table: "album",
+                column: "id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_album_artists_artist_id",
+                table: "album",
+                column: "artist_id",
+                principalTable: "artists",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_tracks_album_album_id",
+                table: "tracks",
+                column: "album_id",
+                principalTable: "album",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_user_album_users_user_id",
+                table: "user_album",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_user_track_users_user_id",
+                table: "user_track",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "user_id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200820193736_AddLastScrobbleUpdateDate.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200820193736_AddLastScrobbleUpdateDate.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200820193736_AddLastScrobbleUpdateDate")]
+    partial class AddLastScrobbleUpdateDate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200820193736_AddLastScrobbleUpdateDate.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200820193736_AddLastScrobbleUpdateDate.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class AddLastScrobbleUpdateDate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_scrobble_update",
+                table: "users",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_scrobble_update",
+                table: "users");
+        }
+    }
+}

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200823192926_AddArtistAliasesAndGenres.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200823192926_AddArtistAliasesAndGenres.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200823192926_AddArtistAliasesAndGenres")]
+    partial class AddArtistAliasesAndGenres
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200823192926_AddArtistAliasesAndGenres.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200823192926_AddArtistAliasesAndGenres.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class AddArtistAliasesAndGenres : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "genres",
+                table: "artists");
+
+            migrationBuilder.CreateTable(
+                name: "artist_aliases",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    artist_id = table.Column<int>(nullable: false),
+                    alias = table.Column<string>(nullable: true),
+                    corrects_in_scrobbles = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_artist_aliases", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_artist_aliases_artists_artist_id",
+                        column: x => x.artist_id,
+                        principalTable: "artists",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "artist_genres",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    artist_id = table.Column<int>(nullable: false),
+                    name = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_artist_genres", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_artist_genres_artists_artist_id",
+                        column: x => x.artist_id,
+                        principalTable: "artists",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_artist_aliases_artist_id",
+                table: "artist_aliases",
+                column: "artist_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_artist_genres_artist_id",
+                table: "artist_genres",
+                column: "artist_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "artist_aliases");
+
+            migrationBuilder.DropTable(
+                name: "artist_genres");
+
+            migrationBuilder.AddColumn<string>(
+                name: "genres",
+                table: "artists",
+                type: "text",
+                nullable: true);
+        }
+    }
+}

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200830204108_RenameArtistIdForBackwardsCompatibility.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200830204108_RenameArtistIdForBackwardsCompatibility.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200830204108_RenameArtistIdForBackwardsCompatibility")]
+    partial class RenameArtistIdForBackwardsCompatibility
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200830204108_RenameArtistIdForBackwardsCompatibility.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200830204108_RenameArtistIdForBackwardsCompatibility.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class RenameArtistIdForBackwardsCompatibility : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists");
+
+            migrationBuilder.DropColumn(
+                name: "user_artist_id",
+                table: "user_artists");
+
+            migrationBuilder.AddColumn<int>(
+                name: "artist_id",
+                table: "user_artists",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists",
+                column: "artist_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists");
+
+            migrationBuilder.DropColumn(
+                name: "artist_id",
+                table: "user_artists");
+
+            migrationBuilder.AddColumn<int>(
+                name: "user_artist_id",
+                table: "user_artists",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0)
+                .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+            migrationBuilder.AddPrimaryKey(
+                name: "pk_user_artists",
+                table: "user_artists",
+                column: "user_artist_id");
+        }
+    }
+}

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200831180315_RemoveTimestampsFromUserData.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200831180315_RemoveTimestampsFromUserData.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200831180315_RemoveTimestampsFromUserData")]
+    partial class RemoveTimestampsFromUserData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20200831180315_RemoveTimestampsFromUserData.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20200831180315_RemoveTimestampsFromUserData.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    public partial class RemoveTimestampsFromUserData : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_updated",
+                table: "user_tracks");
+
+            migrationBuilder.DropColumn(
+                name: "last_updated",
+                table: "user_artists");
+
+            migrationBuilder.DropColumn(
+                name: "last_updated",
+                table: "user_albums");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_updated",
+                table: "user_tracks",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_updated",
+                table: "user_artists",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_updated",
+                table: "user_albums",
+                type: "timestamp without time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+    }
+}


### PR DESCRIPTION
- Rewrite indexing process (#91)
- Add update command (#91)
- Add automatic updating
- Add `UserUpdateFrequencyInHours` to the lastfm section of the config
- Add whoknowsalbum and whoknowstrack (#95)
- Fix `.fm` if the user requesting can't embed links
- Hide youtube embeds if the user requesting can't embed links
- Move all logging to serilog
- Improve command logging
- Fix `.fmstats` if user doesn't have a profile picture on last.fm
- Fix custom prefix not visible in some places
- Allow | as separator for bypassing search in album and track commands