### PR TITLE
Merge dev to main

### DIFF
--- a/src/FMBot.Bot/Commands/AdminCommands.cs
+++ b/src/FMBot.Bot/Commands/AdminCommands.cs
@@ -17,7 +17,6 @@ namespace FMBot.Bot.Commands
     public class AdminCommands : ModuleBase
     {
         private readonly AdminService _adminService;
-        private readonly Logger.Logger _logger;
         private readonly TimerService _timer;
 
         private readonly EmbedBuilder _embed;
@@ -25,12 +24,14 @@ namespace FMBot.Bot.Commands
         private readonly UserService _userService;
         private readonly GuildService _guildService;
 
-        public AdminCommands(TimerService timer, Logger.Logger logger, GuildService guildService)
+        public AdminCommands(
+            TimerService timer,
+            GuildService guildService,
+            UserService userService)
         {
             this._timer = timer;
-            this._logger = logger;
             this._guildService = guildService;
-            this._userService = new UserService();
+            this._userService = userService;
             this._adminService = new AdminService();
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);

--- a/src/FMBot.Bot/Commands/AdminCommands.cs
+++ b/src/FMBot.Bot/Commands/AdminCommands.cs
@@ -27,12 +27,13 @@ namespace FMBot.Bot.Commands
         public AdminCommands(
             TimerService timer,
             GuildService guildService,
-            UserService userService)
+            UserService userService,
+            AdminService adminService)
         {
             this._timer = timer;
             this._guildService = guildService;
             this._userService = userService;
-            this._adminService = new AdminService();
+            this._adminService = adminService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
         }

--- a/src/FMBot.Bot/Commands/AdminCommands.cs
+++ b/src/FMBot.Bot/Commands/AdminCommands.cs
@@ -38,54 +38,54 @@ namespace FMBot.Bot.Commands
                 .WithColor(Constants.LastFMColorRed);
         }
 
-        [Command("debug")]
-        [Summary("Returns user data")]
-        [Alias("dbcheck")]
-        public async Task DebugAsync(IUser user = null)
-        {
-            var chosenUser = user ?? this.Context.Message.Author;
-            var userSettings = await this._userService.GetFullUserAsync(chosenUser);
+        //[Command("debug")]
+        //[Summary("Returns user data")]
+        //[Alias("dbcheck")]
+        //public async Task DebugAsync(IUser user = null)
+        //{
+        //    var chosenUser = user ?? this.Context.Message.Author;
+        //    var userSettings = await this._userService.GetFullUserAsync(chosenUser);
 
-            if (userSettings?.UserNameLastFM == null)
-            {
-                await ReplyAsync("The user's Last.FM name has not been set.");
-                this.Context.LogCommandUsed(CommandResponse.UsernameNotSet);
-                return;
-            }
+        //    if (userSettings?.UserNameLastFM == null)
+        //    {
+        //        await ReplyAsync("The user's Last.FM name has not been set.");
+        //        this.Context.LogCommandUsed(CommandResponse.UsernameNotSet);
+        //        return;
+        //    }
 
-            this._embed.WithTitle($"Debug for {chosenUser.ToString()}");
+        //    this._embed.WithTitle($"Debug for {chosenUser.ToString()}");
 
-            var description = "";
-            foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(userSettings))
-            {
-                var name = descriptor.Name;
-                var value = descriptor.GetValue(userSettings);
+        //    var description = "";
+        //    foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(userSettings))
+        //    {
+        //        var name = descriptor.Name;
+        //        var value = descriptor.GetValue(userSettings);
 
-                if (descriptor.PropertyType.Name == "ICollection`1")
-                {
-                    continue;
-                }
+        //        if (descriptor.PropertyType.Name == "ICollection`1")
+        //        {
+        //            continue;
+        //        }
 
-                if (value != null)
-                {
-                    description += $"{name}: `{value}` \n";
-                }
-                else
-                {
-                    description += $"{name}: null \n";
-                }
-            }
+        //        if (value != null)
+        //        {
+        //            description += $"{name}: `{value}` \n";
+        //        }
+        //        else
+        //        {
+        //            description += $"{name}: null \n";
+        //        }
+        //    }
 
-            description += $"Friends: `{userSettings.Friends.Count}`\n";
-            description += $"Befriended by: `{userSettings.FriendedByUsers.Count}`\n";
-            //description += $"Indexed artists: `{userSettings.Artists.Count}`";
-            //description += $"Indexed albums: `{userSettings.Albums.Count}`";
-            //description += $"Indexed tracks: `{userSettings.Tracks.Count}`";
+        //    description += $"Friends: `{userSettings.Friends.Count}`\n";
+        //    description += $"Befriended by: `{userSettings.FriendedByUsers.Count}`\n";
+        //    //description += $"Indexed artists: `{userSettings.Artists.Count}`";
+        //    //description += $"Indexed albums: `{userSettings.Albums.Count}`";
+        //    //description += $"Indexed tracks: `{userSettings.Tracks.Count}`";
 
-            this._embed.WithDescription(description);
-            await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
-            this.Context.LogCommandUsed();
-        }
+        //    this._embed.WithDescription(description);
+        //    await ReplyAsync("", false, this._embed.Build()).ConfigureAwait(false);
+        //    this.Context.LogCommandUsed();
+        //}
 
 
         [Command("serverdebug")]

--- a/src/FMBot.Bot/Commands/FriendsCommands.cs
+++ b/src/FMBot.Bot/Commands/FriendsCommands.cs
@@ -24,22 +24,21 @@ namespace FMBot.Bot.Commands
         private readonly FriendsService _friendsService;
         private readonly GuildService _guildService;
         private readonly LastFMService _lastFmService;
-        private readonly Logger.Logger _logger;
         private readonly UserService _userService;
 
         private readonly IPrefixService _prefixService;
 
-        public FriendsCommands(Logger.Logger logger,
+        public FriendsCommands(
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
             GuildService guildService,
-            LastFMService lastFmService)
+            LastFMService lastFmService,
+            UserService userService,
+            FriendsService friendsService)
         {
-            this._logger = logger;
             this._prefixService = prefixService;
             this._guildService = guildService;
-            this._userService = new UserService();
-            this._friendsService = new FriendsService();
+            this._userService = userService;
+            this._friendsService = friendsService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -53,7 +52,7 @@ namespace FMBot.Bot.Commands
         [LoginRequired]
         public async Task FriendsAsync()
         {
-            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User, bypassCache: true);
 
             try
             {
@@ -258,7 +257,7 @@ namespace FMBot.Bot.Commands
         [LoginRequired]
         public async Task RemoveFriends([Summary("Friend names")] params string[] enteredFriends)
         {
-            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User, bypassCache: true);
 
             if (enteredFriends.Length == 0)
             {
@@ -341,7 +340,7 @@ namespace FMBot.Bot.Commands
         [LoginRequired]
         public async Task RemoveAllFriends()
         {
-            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User, bypassCache: true);
 
             try
             {

--- a/src/FMBot.Bot/Commands/FriendsCommands.cs
+++ b/src/FMBot.Bot/Commands/FriendsCommands.cs
@@ -344,7 +344,7 @@ namespace FMBot.Bot.Commands
 
             try
             {
-                await this._friendsService.RemoveAllLastFMFriendsAsync(userSettings.UserId);
+                await this._friendsService.RemoveAllFriendsAsync(userSettings.UserId);
 
                 await ReplyAsync("Removed all your friends.");
                 this.Context.LogCommandUsed();

--- a/src/FMBot.Bot/Commands/GeniusCommands.cs
+++ b/src/FMBot.Bot/Commands/GeniusCommands.cs
@@ -20,21 +20,21 @@ namespace FMBot.Bot.Commands
         private readonly EmbedFooterBuilder _embedFooter;
 
         private readonly LastFMService _lastFmService;
-        private readonly Logger.Logger _logger;
-        private readonly GeniusService _geniusService = new GeniusService();
+        private readonly GeniusService _geniusService;
 
         private readonly UserService _userService;
 
         private readonly IPrefixService _prefixService;
 
-        public GeniusCommands(Logger.Logger logger,
+        public GeniusCommands(
             IPrefixService prefixService,
             LastFMService lastFmService,
-            UserService userService)
+            UserService userService,
+            GeniusService geniusService)
         {
-            this._logger = logger;
             this._prefixService = prefixService;
             this._userService = userService;
+            this._geniusService = geniusService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -65,7 +65,7 @@ namespace FMBot.Bot.Commands
 
                     if (tracks?.Any() != true)
                     {
-                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, this.Context, this._logger);
+                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, prfx);
                         await ReplyAsync("", false, this._embed.Build());
                         this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                         return;

--- a/src/FMBot.Bot/Commands/GeniusCommands.cs
+++ b/src/FMBot.Bot/Commands/GeniusCommands.cs
@@ -29,12 +29,12 @@ namespace FMBot.Bot.Commands
 
         public GeniusCommands(Logger.Logger logger,
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
-            LastFMService lastFmService)
+            LastFMService lastFmService,
+            UserService userService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
-            this._userService = new UserService();
+            this._userService = userService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);

--- a/src/FMBot.Bot/Commands/GuildCommands.cs
+++ b/src/FMBot.Bot/Commands/GuildCommands.cs
@@ -25,16 +25,16 @@ namespace FMBot.Bot.Commands
 
         private readonly CommandService _commands;
 
-        private readonly Logger.Logger _logger;
-
         private readonly EmbedBuilder _embed;
         private readonly EmbedAuthorBuilder _embedAuthor;
         private readonly EmbedFooterBuilder _embedFooter;
 
-        public GuildCommands(IPrefixService prefixService, Logger.Logger logger, GuildService guildService, CommandService commands, IDisabledCommandService disabledCommandService)
+        public GuildCommands(IPrefixService prefixService,
+            GuildService guildService,
+            CommandService commands,
+            IDisabledCommandService disabledCommandService)
         {
             this._prefixService = prefixService;
-            this._logger = logger;
             this._guildService = guildService;
             this._commands = commands;
             this._disabledCommandService = disabledCommandService;

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -61,7 +61,7 @@ namespace FMBot.Bot.Commands
                 var indexedUserCount = await this._indexService.GetIndexedUsersCount(guildUsers);
 
                 var guildRecentlyIndexed =
-                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(45));
+                    lastIndex != null && lastIndex > DateTime.UtcNow.Add(-TimeSpan.FromMinutes(60));
 
                 if (guildRecentlyIndexed)
                 {
@@ -165,7 +165,7 @@ namespace FMBot.Bot.Commands
             }
 
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
-            if (userSettings.LastUpdated > DateTime.UtcNow.AddMinutes(-3))
+            if (userSettings.LastUpdated > DateTime.UtcNow.AddMinutes(-15))
             {
                 await ReplyAsync(
                     "You have already been updated recently. Note that this also happens automatically.");

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -130,7 +130,7 @@ namespace FMBot.Bot.Commands
 
                 await this._indexService.StoreGuildUsers(this.Context.Guild, guildUsers);
 
-                this._indexService.IndexGuild(users);
+                this._indexService.AddUsersToIndexQueue(users);
             }
             catch (Exception e)
             {
@@ -164,7 +164,7 @@ namespace FMBot.Bot.Commands
                 return;
             }
 
-            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User, true);
             if (userSettings.LastUpdated > DateTime.UtcNow.AddMinutes(-15))
             {
                 await ReplyAsync(

--- a/src/FMBot.Bot/Commands/IndexCommands.cs
+++ b/src/FMBot.Bot/Commands/IndexCommands.cs
@@ -72,10 +72,11 @@ namespace FMBot.Bot.Commands
                 if (users.Count == 0 && lastIndex != null)
                 {
                     await this._indexService.StoreGuildUsers(this.Context.Guild, guildUsers);
+                    await this._guildService.UpdateGuildIndexTimestampAsync(this.Context.Guild, DateTime.UtcNow);
 
                     var reply =
-                        $"No new registered .fmbot members found on this server or all users have already been indexed. Note that updating users happens automatically, but you can also manually update yourself using `.fmupdate`.\n" +
-                        $"Stored guild users have been updated.";
+                        "Stored guild users have been updated.\n" +
+                        "No new registered .fmbot members found on this server or all users have already been indexed. To update your indexed artist/albums/tracks, use `.fmupdate` (also happens automatically).";
 
                     await ReplyAsync(reply);
                     this.Context.LogCommandUsed(CommandResponse.Cooldown);

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -75,7 +75,7 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var searchResult = await this.SearchAlbum(albumValues, userSettings);
+            var searchResult = await this.SearchAlbum(albumValues, userSettings, prfx);
             if (!searchResult.AlbumFound)
             {
                 this.Context.LogCommandUsed(CommandResponse.NotFound);
@@ -163,7 +163,7 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var searchResult = await this.SearchAlbum(albumValues, userSettings);
+            var searchResult = await this.SearchAlbum(albumValues, userSettings, prfx);
             if (!searchResult.AlbumFound)
             {
                 this.Context.LogCommandUsed(CommandResponse.NotFound);
@@ -223,7 +223,7 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var searchResult = await this.SearchAlbum(albumValues, userSettings);
+            var searchResult = await this.SearchAlbum(albumValues, userSettings, prfx);
             if (!searchResult.AlbumFound)
             {
                 this.Context.LogCommandUsed(CommandResponse.NotFound);
@@ -271,7 +271,7 @@ namespace FMBot.Bot.Commands.LastFM
             this.Context.LogCommandUsed();
         }
 
-        private async Task<AlbumSearchModel> SearchAlbum(string[] albumValues, User userSettings)
+        private async Task<AlbumSearchModel> SearchAlbum(string[] albumValues, User userSettings, string prfx)
         {
             if (albumValues.Any())
             {
@@ -308,7 +308,8 @@ namespace FMBot.Bot.Commands.LastFM
 
                 if (track == null)
                 {
-                    this._embed.NoScrobblesFoundErrorResponse(track.Status, this.Context, this._logger);
+                    this._embed.NoScrobblesFoundErrorResponse(track.Status, prfx);
+                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                     await this.ReplyAsync("", false, this._embed.Build());
                     return new AlbumSearchModel(false);
                 }
@@ -366,7 +367,8 @@ namespace FMBot.Bot.Commands.LastFM
 
                 if (albums?.Any() != true)
                 {
-                    this._embed.NoScrobblesFoundErrorResponse(albums.Status, this.Context, this._logger);
+                    this._embed.NoScrobblesFoundErrorResponse(albums.Status, prfx);
+                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                     await ReplyAsync("", false, this._embed.Build());
                     return;
                 }
@@ -476,7 +478,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             _ = this.Context.Channel.TriggerTypingAsync();
 
-            var searchResult = await this.SearchAlbum(albumValues, userSettings);
+            var searchResult = await this.SearchAlbum(albumValues, userSettings, prfx);
             if (!searchResult.AlbumFound)
             {
                 this.Context.LogCommandUsed(CommandResponse.NotFound);

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -29,19 +29,16 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly GuildService _guildService;
         private readonly LastFMService _lastFmService;
         private readonly IPrefixService _prefixService;
-        private readonly Logger.Logger _logger;
 
         private readonly UserService _userService;
 
-        public ChartCommands(Logger.Logger logger,
+        public ChartCommands(
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
             IChartService chartService,
             GuildService guildService,
             UserService userService,
             LastFMService lastFmService)
         {
-            this._logger = logger;
             this._prefixService = prefixService;
             this._chartService = chartService;
             this._guildService = guildService;

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -654,6 +654,11 @@ namespace FMBot.Bot.Commands.LastFM
         [LoginRequired]
         public async Task WhoKnowsAsync(params string[] trackValues)
         {
+            await ReplyAsync("Whoknows track has been temporarily disabled due to performance issues that caused the database to slow down and the bot to be unusable.\n" +
+                             "Sorry for the inconvenience, we're hoping to get it back as soon as possible.");
+            this.Context.LogCommandUsed(CommandResponse.Disabled);
+            return;
+
             if (this._guildService.CheckIfDM(this.Context))
             {
                 await ReplyAsync("This command is not supported in DMs.");

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -30,7 +30,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly GuildService _guildService;
         private readonly LastFMService _lastFmService;
         private readonly WhoKnowsTrackService _whoKnowsTrackService;
-        private readonly SpotifyService _spotifyService = new SpotifyService();
+        private readonly SpotifyService _spotifyService;
         private readonly Logger.Logger _logger;
 
         private readonly UserService _userService;
@@ -42,6 +42,7 @@ namespace FMBot.Bot.Commands.LastFM
             GuildService guildService,
             UserService userService,
             LastFMService lastFmService,
+            SpotifyService spotifyService,
             WhoKnowsTrackService whoKnowsTrackService)
         {
             this._logger = logger;
@@ -49,6 +50,7 @@ namespace FMBot.Bot.Commands.LastFM
             this._guildService = guildService;
             this._userService = userService;
             this._lastFmService = lastFmService;
+            this._spotifyService = spotifyService;
             this._whoKnowsTrackService = whoKnowsTrackService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -68,7 +70,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (userSettings?.UserNameLastFM == null)
             {
-                this._embed.UsernameNotSetErrorResponse(this.Context, prfx, this._logger);
+                this._embed.UsernameNotSetErrorResponse(prfx);
                 await ReplyAsync("", false, this._embed.Build());
                 return;
             }
@@ -132,7 +134,8 @@ namespace FMBot.Bot.Commands.LastFM
 
                 if (recentScrobbles?.Any() != true)
                 {
-                    this._embed.NoScrobblesFoundErrorResponse(recentScrobbles.Status, this.Context, this._logger);
+                    this._embed.NoScrobblesFoundErrorResponse(recentScrobbles.Status, prfx);
+                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                     await ReplyAsync("", false, this._embed.Build());
                     return;
                 }
@@ -343,7 +346,8 @@ namespace FMBot.Bot.Commands.LastFM
 
                 if (tracks?.Any() != true)
                 {
-                    this._embed.NoScrobblesFoundErrorResponse(tracks.Status, this.Context, this._logger);
+                    this._embed.NoScrobblesFoundErrorResponse(tracks.Status, prfx);
+                    this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                     await ReplyAsync("", false, this._embed.Build());
                     return;
                 }
@@ -436,7 +440,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             _ = this.Context.Channel.TriggerTypingAsync();
 
-            var track = await this.SearchTrack(trackValues, userSettings);
+            var track = await this.SearchTrack(trackValues, userSettings, prfx);
             if (track == null)
             {
                 return;
@@ -523,7 +527,7 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var track = await this.SearchTrack(trackValues, userSettings);
+            var track = await this.SearchTrack(trackValues, userSettings, prfx);
             if (track == null)
             {
                 return;
@@ -733,7 +737,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             _ = this.Context.Channel.TriggerTypingAsync();
 
-            var track = await this.SearchTrack(trackValues, userSettings);
+            var track = await this.SearchTrack(trackValues, userSettings, prfx);
             if (track == null)
             {
                 return;
@@ -829,7 +833,7 @@ namespace FMBot.Bot.Commands.LastFM
             return null;
         }
 
-        private async Task<ResponseTrack> SearchTrack(string[] trackValues, User userSettings)
+        private async Task<ResponseTrack> SearchTrack(string[] trackValues, User userSettings, string prfx)
         {
             string searchValue;
             if (trackValues.Any())
@@ -849,7 +853,7 @@ namespace FMBot.Bot.Commands.LastFM
 
                 if (!track.Content.Any())
                 {
-                    this._embed.NoScrobblesFoundErrorResponse(track.Status, this.Context, this._logger);
+                    this._embed.NoScrobblesFoundErrorResponse(track.Status, prfx);
                     await this.ReplyAsync("", false, this._embed.Build());
                     this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                     return null;

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -582,7 +582,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (trackLoved)
             {
-                this._embed.WithTitle($"❤️ Added loved track for {userTitle}");
+                this._embed.WithTitle($"❤️ Loved track for {userTitle}");
                 this._embed.WithDescription(LastFMService.ResponseTrackToLinkedString(track));
             }
             else

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -583,18 +583,12 @@ namespace FMBot.Bot.Commands.LastFM
             if (trackLoved)
             {
                 this._embed.WithTitle($"❤️ Added loved track for {userTitle}");
-
-                if (Uri.IsWellFormedUriString(track.Url, UriKind.Absolute))
-                {
-                    this._embed.WithUrl(track.Url);
-                }
-
                 this._embed.WithDescription(LastFMService.ResponseTrackToLinkedString(track));
             }
             else
             {
                 await this.Context.Message.Channel.SendMessageAsync(
-                    "Something went wrong while adding loved track, pls report to dev tyty");
+                    "Something went wrong while adding loved track.");
                 this.Context.LogCommandUsed(CommandResponse.Error);
                 return;
             }
@@ -636,18 +630,12 @@ namespace FMBot.Bot.Commands.LastFM
             if (trackLoved)
             {
                 this._embed.WithTitle($"💔 Unloved track for {userTitle}");
-
-                if (Uri.IsWellFormedUriString(track.Url, UriKind.Absolute))
-                {
-                    this._embed.WithUrl(track.Url);
-                }
-
                 this._embed.WithDescription(LastFMService.ResponseTrackToLinkedString(track));
             }
             else
             {
                 await this.Context.Message.Channel.SendMessageAsync(
-                    "Something went wrong while unloving track, pls report to dev tyty");
+                    "Something went wrong while unloving track.");
                 this.Context.LogCommandUsed(CommandResponse.Error);
                 return;
             }

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
+using FMBot.Bot.Attributes;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
@@ -57,18 +58,11 @@ namespace FMBot.Bot.Commands.LastFM
 
         [Command("stats", RunMode = RunMode.Async)]
         [Summary("Displays user stats related to Last.FM and FMBot")]
+        [LoginRequired]
         public async Task StatsAsync(string user = null)
         {
             var userSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
             var prfx = this._prefixService.GetPrefix(this.Context.Guild.Id) ?? ConfigData.Data.Bot.Prefix;
-
-            if (userSettings?.UserNameLastFM == null)
-            {
-                this._embed.UsernameNotSetErrorResponse(this.Context, prfx, this._logger);
-                await ReplyAsync("", false, this._embed.Build());
-                this.Context.LogCommandUsed(CommandResponse.UsernameNotSet);
-                return;
-            }
 
             try
             {
@@ -104,7 +98,7 @@ namespace FMBot.Bot.Commands.LastFM
                 this._embed.WithTitle("Click here to go to profile");
 
                 this._embedFooter.WithText(
-                    "To see info for other users, use .fmstats 'Discord username/ Last.FM username'");
+                    $"To see info for other users, use {prfx}stats 'Discord username/ Last.FM username'");
                 this._embed.WithFooter(this._embedFooter);
 
                 var userInfo = await this._lastFmService.GetUserInfoAsync(lastFMUserName);

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -35,17 +35,18 @@ namespace FMBot.Bot.Commands.LastFM
         public UserCommands(TimerService timer,
             Logger.Logger logger,
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
             GuildService guildService,
             LastFMService lastFmService,
-            IIndexService indexService)
+            IIndexService indexService,
+            UserService userService,
+            FriendsService friendsService)
         {
             this._timer = timer;
             this._logger = logger;
             this._prefixService = prefixService;
             this._guildService = guildService;
-            this._friendsService = new FriendsService();
-            this._userService = new UserService();
+            this._friendsService = friendsService;
+            this._userService = userService;
             this._lastFmService = lastFmService;
             this._indexService = indexService;
             this._embed = new EmbedBuilder()
@@ -173,7 +174,7 @@ namespace FMBot.Bot.Commands.LastFM
         {
             var prfx = ConfigData.Data.Bot.Prefix;
 
-            var existingUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var existingUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User, true);
             if (lastFMUserName == null || lastFMUserName == "help")
             {
                 var replyString = $"{prfx}set is the command you use to set your last.fm username in the bot, so it knows who you are on the last.fm website. \n" +
@@ -242,7 +243,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             this.Context.LogCommandUsed();
 
-            var newUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
+            var newUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User, true);
             if (existingUserSettings == null ||
                 existingUserSettings.UserNameLastFM.ToLower() != newUserSettings.UserNameLastFM.ToLower())
             {
@@ -251,7 +252,7 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (!this._guildService.CheckIfDM(this.Context))
             {
-                await this._indexService.AddUserToGuild(Context.Guild, newUserSettings);
+                await this._indexService.AddUserToGuild(this.Context.Guild, newUserSettings);
 
                 var perms = await this._guildService.CheckSufficientPermissionsAsync(this.Context);
                 if (!perms.EmbedLinks || !perms.AttachFiles)

--- a/src/FMBot.Bot/Commands/OwnerCommands.cs
+++ b/src/FMBot.Bot/Commands/OwnerCommands.cs
@@ -18,14 +18,11 @@ namespace FMBot.Bot.Commands
     [Summary("FMBot Owners Only")]
     public class OwnerCommands : ModuleBase
     {
-        private readonly Logger.Logger _logger;
-
         private readonly AdminService _adminService;
 
-        public OwnerCommands(Logger.Logger logger)
+        public OwnerCommands(AdminService adminService)
         {
-            this._logger = logger;
-            this._adminService = new AdminService();
+            this._adminService = adminService;
         }
 
         [Command("setusertype"), Summary("Sets usertype for other users")]

--- a/src/FMBot.Bot/Commands/SpotifyCommands.cs
+++ b/src/FMBot.Bot/Commands/SpotifyCommands.cs
@@ -29,12 +29,12 @@ namespace FMBot.Bot.Commands
         public SpotifyCommands(
             Logger.Logger logger,
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
-            LastFMService lastFmService)
+            LastFMService lastFmService,
+            UserService userService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
-            this._userService = new UserService();
+            this._userService = userService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);

--- a/src/FMBot.Bot/Commands/SpotifyCommands.cs
+++ b/src/FMBot.Bot/Commands/SpotifyCommands.cs
@@ -19,22 +19,21 @@ namespace FMBot.Bot.Commands
         private readonly EmbedBuilder _embed;
 
         private readonly LastFMService _lastFmService;
-        private readonly Logger.Logger _logger;
-        private readonly SpotifyService _spotifyService = new SpotifyService();
+        private readonly SpotifyService _spotifyService;
 
         private readonly UserService _userService;
 
         private readonly IPrefixService _prefixService;
 
         public SpotifyCommands(
-            Logger.Logger logger,
             IPrefixService prefixService,
             LastFMService lastFmService,
-            UserService userService)
+            UserService userService,
+            SpotifyService spotifyService)
         {
-            this._logger = logger;
             this._prefixService = prefixService;
             this._userService = userService;
+            this._spotifyService = spotifyService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -64,7 +63,8 @@ namespace FMBot.Bot.Commands
 
                     if (tracks?.Any() != true)
                     {
-                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, this.Context, this._logger);
+                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, prfx);
+                        this.Context.LogCommandUsed(CommandResponse.NoScrobbles);
                         await ReplyAsync("", false, this._embed.Build());
                         return;
                     }

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -27,12 +27,16 @@ namespace FMBot.Bot.Commands
         private readonly UserService _userService;
         private readonly FriendsService _friendService;
 
-        public StaticCommands(CommandService service, IPrefixService prefixService)
+        public StaticCommands(
+            CommandService service,
+            IPrefixService prefixService,
+            UserService userService,
+            FriendsService friendsService)
         {
             this._service = service;
             this._prefixService = prefixService;
-            this._userService = new UserService();
-            this._friendService = new FriendsService();
+            this._userService = userService;
+            this._friendService = friendsService;
             this._guildService = new GuildService();
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -28,11 +28,12 @@ namespace FMBot.Bot.Commands
             Logger.Logger logger,
             IPrefixService prefixService,
             ILastfmApi lastfmApi,
-            LastFMService lastFmService)
+            LastFMService lastFmService,
+            UserService userService)
         {
             this._logger = logger;
             this._prefixService = prefixService;
-            this._userService = new UserService();
+            this._userService = userService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);

--- a/src/FMBot.Bot/Commands/YoutubeCommands.cs
+++ b/src/FMBot.Bot/Commands/YoutubeCommands.cs
@@ -18,22 +18,20 @@ namespace FMBot.Bot.Commands
         private readonly EmbedBuilder _embed;
 
         private readonly LastFMService _lastFmService;
-        private readonly Logger.Logger _logger;
         private readonly UserService _userService;
-        private readonly YoutubeService _youtubeService = new YoutubeService();
+        private readonly YoutubeService _youtubeService;
 
         private readonly IPrefixService _prefixService;
 
         public YoutubeCommands(
-            Logger.Logger logger,
             IPrefixService prefixService,
-            ILastfmApi lastfmApi,
             LastFMService lastFmService,
-            UserService userService)
+            UserService userService,
+            YoutubeService youtubeService)
         {
-            this._logger = logger;
             this._prefixService = prefixService;
             this._userService = userService;
+            this._youtubeService = youtubeService;
             this._lastFmService = lastFmService;
             this._embed = new EmbedBuilder()
                 .WithColor(Constants.LastFMColorRed);
@@ -63,7 +61,7 @@ namespace FMBot.Bot.Commands
 
                     if (tracks?.Any() != true)
                     {
-                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, this.Context, this._logger);
+                        this._embed.NoScrobblesFoundErrorResponse(tracks.Status, prfx);
                         await ReplyAsync("", false, this._embed.Build());
                         return;
                     }
@@ -95,7 +93,7 @@ namespace FMBot.Bot.Commands
                     var rnd = new Random();
                     if (rnd.Next(0, 5) == 1 && searchValues.Length < 1)
                     {
-                        reply += "\n*Tip: Search for other songs or videos by simply adding the searchvalue behind .fmyoutube.*";
+                        reply += $"\n*Tip: Search for other songs or videos by simply adding the searchvalue behind {prfx}youtube.*";
                     }
 
                     await ReplyAsync(reply.FilterOutMentions());
@@ -105,7 +103,8 @@ namespace FMBot.Bot.Commands
                 catch (Exception e)
                 {
                     this.Context.LogCommandException(e);
-                    await ReplyAsync("No results have been found for this query.");
+                    await ReplyAsync("No results have been found for this query.\n" +
+                                     "It could also be that we've currently exceeded the YouTube ratelimits. This is an issue that will be fixed soon.");
                 }
             }
             catch (Exception e)

--- a/src/FMBot.Bot/Configurations/ConfigData.cs
+++ b/src/FMBot.Bot/Configurations/ConfigData.cs
@@ -43,7 +43,8 @@ namespace FMBot.Bot.Configurations
                     Discord = new DiscordConfig(),
                     LastFm = new LastFmConfig
                     {
-                        UserUpdateFrequencyInHours = 24
+                        UserUpdateFrequencyInHours = 24,
+                        UserIndexFrequencyInDays = 120
                     },
                     Genius = new GeniusConfig(),
                     Spotify = new SpotifyConfig(),

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -7,10 +7,12 @@ using Discord.Commands;
 using Discord.WebSocket;
 using FMBot.Bot.Attributes;
 using FMBot.Bot.Configurations;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Domain;
+using FMBot.Domain.Models;
 using Serilog;
 
 namespace FMBot.Bot.Handlers
@@ -144,9 +146,9 @@ namespace FMBot.Bot.Handlers
                 {
                     var embed = new EmbedBuilder()
                         .WithColor(Constants.LastFMColorRed);
-                    var logger = new Logger.Logger();
-                    embed.UsernameNotSetErrorResponse(context, customPrefix ?? ConfigData.Data.Bot.Prefix, logger);
+                    embed.UsernameNotSetErrorResponse(customPrefix ?? ConfigData.Data.Bot.Prefix);
                     await context.Channel.SendMessageAsync("", false, embed.Build());
+                    context.LogCommandUsed(CommandResponse.UsernameNotSet);
                     return;
                 }
             }

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -11,6 +11,7 @@ using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Domain;
+using Serilog;
 
 namespace FMBot.Bot.Handlers
 {
@@ -130,8 +131,7 @@ namespace FMBot.Bot.Handlers
                 }
                 else
                 {
-                    var logger = new Logger.Logger();
-                    logger.LogError(commandPrefixResult.ToString(), context.Message.Content);
+                    Log.Error(commandPrefixResult.ToString(), context.Message.Content);
                 }
 
                 return;
@@ -159,8 +159,7 @@ namespace FMBot.Bot.Handlers
             }
             else
             {
-                var logger = new Logger.Logger();
-                logger.LogError(result.ToString(), context.Message.Content);
+                Log.Error(result.ToString(), context.Message.Content);
             }
         }
 

--- a/src/FMBot.Bot/Interfaces/IIndexService.cs
+++ b/src/FMBot.Bot/Interfaces/IIndexService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Discord;
@@ -7,7 +8,7 @@ namespace FMBot.Bot.Interfaces
 {
     public interface IIndexService
     {
-        void IndexGuild(IReadOnlyList<User> users);
+        void AddUsersToIndexQueue(IReadOnlyList<User> users);
 
         Task IndexUser(User user);
 
@@ -18,5 +19,7 @@ namespace FMBot.Bot.Interfaces
         Task<IReadOnlyList<User>> GetUsersToIndex(IReadOnlyCollection<IGuildUser> guildUsers);
 
         Task<int> GetIndexedUsersCount(IReadOnlyCollection<IGuildUser> guildUsers);
+
+        Task<IReadOnlyList<User>> GetOutdatedUsers(DateTime timeLastIndexed);
     }
 }

--- a/src/FMBot.Bot/Models/ConfigModel.cs
+++ b/src/FMBot.Bot/Models/ConfigModel.cs
@@ -63,6 +63,8 @@ namespace FMBot.Bot.Models
         public string Secret { get; set; }
 
         public int? UserUpdateFrequencyInHours { get; set; }
+
+        public int? UserIndexFrequencyInDays { get; set; }
     }
 
     public class SpotifyConfig

--- a/src/FMBot.Bot/Services/AdminService.cs
+++ b/src/FMBot.Bot/Services/AdminService.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace FMBot.Bot.Services
 {
-    internal class AdminService
+    public class AdminService
     {
         public async Task<bool> HasCommandAccessAsync(IUser discordUser, UserType userType)
         {

--- a/src/FMBot.Bot/Services/ErrorService.cs
+++ b/src/FMBot.Bot/Services/ErrorService.cs
@@ -8,7 +8,7 @@ namespace FMBot.Bot.Services
 {
     public static class ErrorService
     {
-        public static void UsernameNotSetErrorResponse(this EmbedBuilder embed, ICommandContext context, string prfx, Logger.Logger logger)
+        public static void UsernameNotSetErrorResponse(this EmbedBuilder embed, string prfx)
         {
             embed.WithTitle("Error while attempting get Last.FM information");
             embed.WithDescription("Your Last.FM username has not been set. \n" +
@@ -19,10 +19,9 @@ namespace FMBot.Bot.Services
             embed.WithUrl($"{Constants.DocsUrl}/commands/");
 
             embed.WithColor(Constants.WarningColorOrange);
-            logger.LogError("Last.FM username not set", context.Message.Content, context.User.Username, context.Guild?.Name, context.Guild?.Id);
         }
 
-        public static void NoScrobblesFoundErrorResponse(this EmbedBuilder embed, LastResponseStatus apiResponse, ICommandContext context, Logger.Logger logger)
+        public static void NoScrobblesFoundErrorResponse(this EmbedBuilder embed, LastResponseStatus apiResponse, string prfx)
         {
             embed.WithTitle("Error while attempting get Last.FM information");
             switch (apiResponse)
@@ -33,8 +32,8 @@ namespace FMBot.Bot.Services
                     break;
                 case LastResponseStatus.MissingParameters:
                     embed.WithDescription("You or the user you're searching for has no scrobbles/artists on their profile, or Last.FM is having issues. Please try again later. \n \n" +
-                                          "Recently changed your Last.FM username? Please change it here too using `.fmset`. \n" +
-                                          "For more info on your settings, use `.fmset help`.");
+                                          $"Recently changed your Last.FM username? Please change it here too using `{prfx}set`. \n" +
+                                          $"For more info on your settings, use `{prfx}set help`.");
                     break;
                 default:
                     embed.WithDescription(
@@ -44,7 +43,6 @@ namespace FMBot.Bot.Services
 
             embed.WithThumbnailUrl("https://www.last.fm/static/images/marvin.e51495403de9.png");
             embed.WithColor(Constants.WarningColorOrange);
-            logger.LogError($"No scrobbles found for user, error code {apiResponse}", context.Message.Content, context.User.Username, context.Guild?.Name, context.Guild?.Id);
         }
 
         public static void ErrorResponse(this EmbedBuilder embed, ResponseStatus apiResponse, string message, ICommandContext context, Logger.Logger logger)

--- a/src/FMBot.Bot/Services/FriendsService.cs
+++ b/src/FMBot.Bot/Services/FriendsService.cs
@@ -92,20 +92,32 @@ namespace FMBot.Bot.Services
             }
         }
 
-        public async Task RemoveAllLastFMFriendsAsync(int userID)
+        public async Task RemoveAllFriendsAsync(int userId)
         {
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             var friends = db.Friends
                 .AsQueryable()
-                .Where(f => f.UserId == userID).ToList();
+                .Where(f => f.UserId == userId).ToList();
 
             if (friends.Count > 0)
             {
                 db.Friends.RemoveRange(friends);
                 await db.SaveChangesAsync();
             }
+        }
 
-            await Task.CompletedTask;
+        public async Task RemoveUserFromOtherFriendsAsync(int userId)
+        {
+            await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
+            var friends = db.Friends
+                .AsQueryable()
+                .Where(f => f.FriendUserId == userId).ToList();
+
+            if (friends.Count > 0)
+            {
+                db.Friends.RemoveRange(friends);
+                await db.SaveChangesAsync();
+            }
         }
 
         public async Task<int> GetTotalFriendCountAsync()

--- a/src/FMBot.Bot/Services/FriendsService.cs
+++ b/src/FMBot.Bot/Services/FriendsService.cs
@@ -6,11 +6,19 @@ using FMBot.Bot.Configurations;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace FMBot.Bot.Services
 {
     public class FriendsService
     {
+        private readonly IMemoryCache _cache;
+
+        public FriendsService(IMemoryCache cache)
+        {
+            this._cache = cache;
+        }
+
         public async Task<IReadOnlyList<string>> GetFMFriendsAsync(IUser discordUser)
         {
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
@@ -32,6 +40,8 @@ namespace FMBot.Bot.Services
         {
             await using var db = new FMBotDbContext(ConfigData.Data.Database.ConnectionString);
             var user = db.Users.FirstOrDefault(f => f.DiscordUserId == discordSenderId);
+
+            this._cache.Remove($"user-settings-{discordSenderId}");
 
             if (user == null)
             {

--- a/src/FMBot.Bot/Services/GeniusService.cs
+++ b/src/FMBot.Bot/Services/GeniusService.cs
@@ -6,7 +6,7 @@ using Genius.Models;
 
 namespace FMBot.Bot.Services
 {
-    internal class GeniusService
+    public class GeniusService
     {
         public async Task<SearchHit> SearchGeniusAsync(string searchValue)
         {

--- a/src/FMBot.Bot/Services/IndexService.cs
+++ b/src/FMBot.Bot/Services/IndexService.cs
@@ -165,6 +165,7 @@ namespace FMBot.Bot.Services
                 .Where(f => f.LastIndexed != null &&
                             f.LastUpdated != null &&
                             f.LastIndexed <= timeLastIndexed)
+                .OrderBy(o => o.LastUpdated)
                 .ToListAsync();
         }
     }

--- a/src/FMBot.Bot/Services/SpotifyService.cs
+++ b/src/FMBot.Bot/Services/SpotifyService.cs
@@ -16,7 +16,7 @@ using Artist = FMBot.Persistence.Domain.Models.Artist;
 
 namespace FMBot.Bot.Services
 {
-    internal class SpotifyService
+    public class SpotifyService
     {
         public async Task<SearchItem> GetSearchResultAsync(string searchValue, SearchType searchType = SearchType.Track)
         {

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -257,8 +257,8 @@ namespace FMBot.Bot.Services
                     this._updateService.AddUsersToUpdateQueue(usersToUpdate);
                 },
                 null,
-                TimeSpan.FromMinutes(1),
-                TimeSpan.FromMinutes(60));
+                TimeSpan.FromMinutes(2),
+                TimeSpan.FromHours(3));
 
             this._timerEnabled = true;
         }

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -26,25 +26,24 @@ namespace FMBot.Bot.Services
         private readonly Timer _externalStatsTimer;
         private readonly Timer _internalStatsTimer;
         private readonly Timer _userUpdateTimer;
-        private readonly ILastfmApi _lastfmApi;
         private readonly LastFMService _lastFMService;
         private readonly UserService _userService;
         private readonly IUpdateService _updateService;
         private readonly GuildService _guildService;
         private readonly DiscordShardedClient _client;
 
-        private readonly ILogger logger = Log.ForContext<TimerService>();
-
         private bool _timerEnabled;
 
         private string _trackString = "";
 
-        public TimerService(DiscordShardedClient client, ILastfmApi lastfmApi, LastFMService lastFmService, IUpdateService updateService)
+        public TimerService(DiscordShardedClient client,
+            LastFMService lastFmService,
+            IUpdateService updateService,
+            UserService userService)
         {
-            this._lastfmApi = lastfmApi;
             this._client = client;
             this._lastFMService = lastFmService;
-            this._userService = new UserService();
+            this._userService = userService;
             this._guildService = new GuildService();
             this._updateService = updateService;
 
@@ -238,7 +237,7 @@ namespace FMBot.Bot.Services
                 },
                 null,
                 TimeSpan.FromSeconds(ConfigData.Data.Bot.BotWarmupTimeInSeconds + 10),
-                TimeSpan.FromMinutes(5));
+                TimeSpan.FromMinutes(30));
 
             this._userUpdateTimer = new Timer(async _ =>
                 {

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Discord;
@@ -58,7 +57,7 @@ namespace FMBot.Bot.Services
                 .AsQueryable()
                 .FirstOrDefaultAsync(f => f.DiscordUserId == discordUser.Id);
 
-            this._cache.Set(cacheKey, user, TimeSpan.FromHours(3));
+            this._cache.Set(cacheKey, user, TimeSpan.FromHours(12));
 
             return user;
         }

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -203,6 +203,11 @@ namespace FMBot.Bot.Services
                 title += " 🔥";
             }
 
+            if (rank == UserType.Backer)
+            {
+                title += " ⭐";
+            }
+
             return title;
         }
 
@@ -246,7 +251,11 @@ namespace FMBot.Bot.Services
                 user.UserNameLastFM = newUserSettings.UserNameLastFM;
                 user.FmEmbedType = newUserSettings.FmEmbedType;
                 user.FmCountType = newUserSettings.FmCountType;
-                user.SessionKeyLastFm = newUserSettings.SessionKeyLastFm;
+
+                if (!string.Equals(user.UserNameLastFM, newUserSettings.UserNameLastFM, StringComparison.CurrentCultureIgnoreCase))
+                {
+                    user.SessionKeyLastFm = newUserSettings.SessionKeyLastFm;
+                }
 
                 db.Entry(user).State = EntityState.Modified;
 

--- a/src/FMBot.Bot/Services/YoutubeService.cs
+++ b/src/FMBot.Bot/Services/YoutubeService.cs
@@ -7,7 +7,7 @@ using Google.Apis.YouTube.v3.Data;
 
 namespace FMBot.Bot.Services
 {
-    internal class YoutubeService
+    public class YoutubeService
     {
         public async Task<SearchResult> GetSearchResult(string searchValue)
         {

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -104,7 +104,11 @@ namespace FMBot.Bot
                 .AddSingleton<IIndexService, IndexService>()
                 .AddSingleton<GuildService>()
                 .AddSingleton<UserService>()
+                .AddSingleton<AdminService>()
                 .AddSingleton<FriendsService>()
+                .AddSingleton<GeniusService>()
+                .AddSingleton<SpotifyService>()
+                .AddSingleton<YoutubeService>()
                 .AddSingleton(logger)
                 .AddSingleton<Random>() // Add random to the collection
                 .AddSingleton(this.Configuration) // Add the configuration to the collection

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -104,6 +104,7 @@ namespace FMBot.Bot
                 .AddSingleton<IIndexService, IndexService>()
                 .AddSingleton<GuildService>()
                 .AddSingleton<UserService>()
+                .AddSingleton<FriendsService>()
                 .AddSingleton(logger)
                 .AddSingleton<Random>() // Add random to the collection
                 .AddSingleton(this.Configuration) // Add the configuration to the collection

--- a/src/FMBot.Discord.sln.DotSettings
+++ b/src/FMBot.Discord.sln.DotSettings
@@ -3,4 +3,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playcount/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=prfx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scrobble/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scrobbles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spotify/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/FMBot.Discord.sln.DotSettings
+++ b/src/FMBot.Discord.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=autocorrect/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Playcount/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=prfx/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Scrobble/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=spotify/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/FMBot.Domain/Models/CommandResponse.cs
+++ b/src/FMBot.Domain/Models/CommandResponse.cs
@@ -24,6 +24,8 @@ namespace FMBot.Domain.Models
 
         IndexRequired = 11,
 
-        LastFmError = 12
+        LastFmError = 12,
+
+        Disabled = 13
     }
 }

--- a/src/FMBot.LastFM.Domain/Types/Calls.cs
+++ b/src/FMBot.LastFM.Domain/Types/Calls.cs
@@ -7,6 +7,7 @@ namespace FMBot.LastFM.Domain.Types
             AlbumInfo = "Album.getInfo",
             TrackInfo = "Track.getInfo",
             TrackLove = "track.love",
+            TrackUnLove = "track.unlove",
             UserInfo = "User.getInfo",
             TopTracks = "user.gettoptracks",
             GetToken = "auth.GetToken",

--- a/src/FMBot.LastFM/FMBot.LastFM.csproj
+++ b/src/FMBot.LastFM/FMBot.LastFM.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Newtonsoft.Json.Schema" Version="3.0.13" />
     <PackageReference Include="Npgsql" Version="4.1.4" />
     <PackageReference Include="PostgreSQLCopyHelper" Version="2.6.3" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="5.6.0" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -51,7 +51,12 @@ namespace FMBot.LastFM.Services
             await InsertAlbumsIntoDatabase(albums, user.UserId);
 
             var tracks = await GetTracksForUserFromLastFm(user);
-            await InsertTracksIntoDatabase(tracks, user.UserId);
+
+            var tracksToInsert = tracks
+                .Where(w => w.Playcount >= 3)
+                .ToList();
+
+            await InsertTracksIntoDatabase(tracksToInsert, user.UserId);
 
             var latestScrobbleDate = await GetLatestScrobbleDate(user);
             await SetUserIndexTime(user.UserId, now, latestScrobbleDate);

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -39,9 +39,9 @@ namespace FMBot.LastFM.Services
 
         public async Task IndexUser(User user)
         {
-            Thread.Sleep(7500);
+            Thread.Sleep(10000);
 
-            Log.Information($"Starting artist store for {user.UserNameLastFM}");
+            Log.Information($"Starting index for {user.UserNameLastFM}");
             var now = DateTime.UtcNow;
 
             var artists = await GetArtistsForUserFromLastFm(user);
@@ -50,8 +50,8 @@ namespace FMBot.LastFM.Services
             var albums = await GetAlbumsForUserFromLastFm(user);
             await InsertAlbumsIntoDatabase(albums, user.UserId);
 
-            //var tracks = await GetTracksForUserFromLastFm(user);
-            //await InsertTracksIntoDatabase(tracks, user.UserId);
+            var tracks = await GetTracksForUserFromLastFm(user);
+            await InsertTracksIntoDatabase(tracks, user.UserId);
 
             var latestScrobbleDate = await GetLatestScrobbleDate(user);
             await SetUserIndexTime(user.UserId, now, latestScrobbleDate);
@@ -159,9 +159,9 @@ namespace FMBot.LastFM.Services
             connection.Open();
 
             await using var deleteCurrentArtists = new NpgsqlCommand($"DELETE FROM public.user_artists WHERE user_id = {userId};", connection);
-            await deleteCurrentArtists.ExecuteNonQueryAsync().ConfigureAwait(false);
+            await deleteCurrentArtists.ExecuteNonQueryAsync();
 
-            await copyHelper.SaveAllAsync(connection, artists).ConfigureAwait(false);
+            await copyHelper.SaveAllAsync(connection, artists);
         }
 
         private async Task InsertAlbumsIntoDatabase(IReadOnlyList<UserAlbum> albums, int userId)
@@ -178,9 +178,9 @@ namespace FMBot.LastFM.Services
             connection.Open();
 
             await using var deleteCurrentAlbums = new NpgsqlCommand($"DELETE FROM public.user_albums WHERE user_id = {userId};", connection);
-            await deleteCurrentAlbums.ExecuteNonQueryAsync().ConfigureAwait(false);
+            await deleteCurrentAlbums.ExecuteNonQueryAsync();
 
-            await copyHelper.SaveAllAsync(connection, albums).ConfigureAwait(false);
+            await copyHelper.SaveAllAsync(connection, albums);
         }
 
         private async Task InsertTracksIntoDatabase(IReadOnlyList<UserTrack> artists, int userId)
@@ -197,9 +197,9 @@ namespace FMBot.LastFM.Services
             connection.Open();
 
             await using var deleteCurrentTracks = new NpgsqlCommand($"DELETE FROM public.user_tracks WHERE user_id = {userId};", connection);
-            await deleteCurrentTracks.ExecuteNonQueryAsync().ConfigureAwait(false);
+            await deleteCurrentTracks.ExecuteNonQueryAsync();
 
-            await copyHelper.SaveAllAsync(connection, artists).ConfigureAwait(false);
+            await copyHelper.SaveAllAsync(connection, artists);
 
         }
 

--- a/src/FMBot.LastFM/Services/GlobalIndexService.cs
+++ b/src/FMBot.LastFM/Services/GlobalIndexService.cs
@@ -130,7 +130,7 @@ namespace FMBot.LastFM.Services
         {
             Log.Information($"Getting tracks for user {user.UserNameLastFM}");
 
-            var trackResult = await this.lastFmService.GetTopTracksAsync(user.UserNameLastFM, "overall", 1000, 8);
+            var trackResult = await this.lastFmService.GetTopTracksAsync(user.UserNameLastFM, "overall", 1000, 6);
 
             if (!trackResult.Success || trackResult.Content.TopTracks.Track.Count == 0)
             {

--- a/src/FMBot.LastFM/Services/GlobalUpdateService.cs
+++ b/src/FMBot.LastFM/Services/GlobalUpdateService.cs
@@ -118,7 +118,6 @@ namespace FMBot.LastFM.Services
                 updateArtistPlaycount.Parameters.AddWithValue("name", artistName);
 
                 await updateArtistPlaycount.ExecuteNonQueryAsync().ConfigureAwait(false);
-                Console.WriteLine($"Adding {artist.Count()} plays to {artistName} for {user.UserNameLastFM}");
             }
 
             Console.WriteLine($"Updated artists for {user.UserNameLastFM}");

--- a/src/FMBot.LastFM/Services/GlobalUpdateService.cs
+++ b/src/FMBot.LastFM/Services/GlobalUpdateService.cs
@@ -37,7 +37,7 @@ namespace FMBot.LastFM.Services
 
         public async Task<int> UpdateUser(User user)
         {
-            Thread.Sleep(750);
+            Thread.Sleep(1000);
 
             Log.Information($"Updating {user.UserNameLastFM}");
 

--- a/src/FMBot.LastFM/Services/LastFMService.cs
+++ b/src/FMBot.LastFM/Services/LastFMService.cs
@@ -69,6 +69,29 @@ namespace FMBot.LastFM.Services
                        : $" | *{track.AlbumName}*\n");
         }
 
+        public static string ResponseTrackToLinkedString(ResponseTrack track)
+        {
+            if (track.Url.IndexOfAny(new[] { '(', ')' }) >= 0)
+            {
+                return ResponseTrackToString(track);
+            }
+
+            return $"[{track.Name}]({track.Url})\n" +
+                   $"By **{track.Artist.Name}**" +
+                   (track.Album == null || string.IsNullOrWhiteSpace(track.Album.Title)
+                       ? "\n"
+                       : $" | *{track.Album.Title}*\n");
+        }
+
+        public static string ResponseTrackToString(ResponseTrack track)
+        {
+            return $"{track.Name}\n" +
+                   $"By **{track.Artist.Name}**" +
+                   (track.Album == null || string.IsNullOrWhiteSpace(track.Album.Title)
+                       ? "\n"
+                       : $" | *{track.Album.Title}*\n");
+        }
+
         public static string TrackToOneLinedString(LastTrack track)
         {
             return $"{track.Name} By **{track.ArtistName}**" +
@@ -316,6 +339,21 @@ namespace FMBot.LastFM.Services
             };
 
             var authSessionCall = await this._lastfmApi.CallApiAsync<AuthSessionResponse>(queryParams, Call.TrackLove, true);
+            Statistics.LastfmApiCalls.Inc();
+
+            return authSessionCall.Success;
+        }
+
+        public async Task<bool> UnLoveTrackAsync(User user, string artistName, string trackName)
+        {
+            var queryParams = new Dictionary<string, string>
+            {
+                {"artist", artistName},
+                {"track", trackName},
+                {"sk", user.SessionKeyLastFm},
+            };
+
+            var authSessionCall = await this._lastfmApi.CallApiAsync<AuthSessionResponse>(queryParams, Call.TrackUnLove, true);
             Statistics.LastfmApiCalls.Inc();
 
             return authSessionCall.Success;

--- a/src/FMBot.LastFM/Services/LastfmApi.cs
+++ b/src/FMBot.LastFM/Services/LastfmApi.cs
@@ -140,7 +140,7 @@ namespace FMBot.LastFM.Services
         private static string CreateMd5(string input)
         {
             using var md5 = System.Security.Cryptography.MD5.Create();
-            var inputBytes = Encoding.ASCII.GetBytes(input);
+            var inputBytes = Encoding.UTF8.GetBytes(input);
             var hashBytes = md5.ComputeHash(inputBytes);
 
             var sb = new StringBuilder();

--- a/src/FMBot.Persistence.Domain/Models/UserType.cs
+++ b/src/FMBot.Persistence.Domain/Models/UserType.cs
@@ -8,6 +8,8 @@ namespace FMBot.Persistence.Domain.Models
 
         Owner = 2,
 
-        Contributor = 3
+        Contributor = 3,
+
+        Backer = 4
     }
 }

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -1,7 +1,6 @@
 using System;
 using FMBot.Persistence.Domain.Models;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 
 namespace FMBot.Persistence.EntityFrameWork
 {

--- a/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/FMBotDbContext.cs
@@ -47,7 +47,10 @@ namespace FMBot.Persistence.EntityFrameWork
                 // When creating migrations, make sure to enter the connection string below.
                 optionsBuilder.UseNpgsql(string.IsNullOrEmpty(this._connectionString)
                     ? "Host=localhost;Port=5433;Username=postgres;Password=password;Database=fmbot;Command Timeout=360;Timeout=360;Persist Security Info=True"
-                    : this._connectionString);
+                    : this._connectionString, builder =>
+                {
+                    builder.EnableRetryOnFailure(3, TimeSpan.FromSeconds(10), null);
+                });
 
                 optionsBuilder.UseSnakeCaseNamingConvention();
             }


### PR DESCRIPTION
- Fix `.fmupdate` process to include new artist/albums/tracks
- Add index update timer to update users that might have been updated wrong by above bug
- Add `.fmlogin` to login using the last.fm authorization flow
- Add `.fmlove` to add a track to your loved tracks
- Add `.fmunlove` to unlove a track
- Improve index messages and responses
- Improve and fix `.fmremove`
- Disable `.fmdebug` because it showed the session token. An alternative will come back later.
- Add `backer` user type.