### PR TITLE
Main to dev

### DIFF
--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -6,10 +6,9 @@ using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Discord;
 using Discord.Commands;
+using Fergun.Interactive;
 using FMBot.Bot.Attributes;
-using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
@@ -22,8 +21,6 @@ using FMBot.Domain.Models;
 using FMBot.LastFM.Domain.Enums;
 using FMBot.LastFM.Repositories;
 using FMBot.Persistence.Domain.Models;
-using Interactivity;
-using Interactivity.Pagination;
 using Microsoft.Extensions.Options;
 using Constants = FMBot.Domain.Constants;
 using ImageFormat = System.Drawing.Imaging.ImageFormat;
@@ -49,7 +46,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly WhoKnowsPlayService _whoKnowsPlayService;
         private readonly WhoKnowsService _whoKnowsService;
 
-        private InteractivityService Interactivity { get; }
+        private InteractiveService Interactivity { get; }
 
         public AlbumCommands(
                 CensorService censorService,
@@ -64,7 +61,7 @@ namespace FMBot.Bot.Commands.LastFM
                 WhoKnowsAlbumService whoKnowsAlbumService,
                 WhoKnowsPlayService whoKnowsPlayService,
                 WhoKnowsService whoKnowsService,
-                InteractivityService interactivity,
+                InteractiveService interactivity,
                 TrackService trackService,
                 SpotifyService spotifyService,
                 IOptions<BotSettings> botSettings,
@@ -393,15 +390,8 @@ namespace FMBot.Bot.Commands.LastFM
 
             var timeSettings = SettingService.GetTimePeriod(extraOptions);
             var userSettings = await this._settingService.GetUser(extraOptions, contextUser, this.Context);
-            var amount = SettingService.GetAmount(extraOptions);
 
-            var paginationEnabled = false;
             var pages = new List<PageBuilder>();
-            var perms = await GuildService.GetGuildPermissionsAsync(this.Context);
-            if (perms.ManageMessages)
-            {
-                paginationEnabled = true;
-            }
 
             string userTitle;
             if (!userSettings.DifferentUser)
@@ -414,16 +404,17 @@ namespace FMBot.Bot.Commands.LastFM
                     $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(this.Context)}";
             }
 
-            this._embedAuthor.WithIconUrl(this.Context.User.GetAvatarUrl());
-            var artistsString = amount == 1 ? "album" : "albums";
-            this._embedAuthor.WithName($"Top {timeSettings.Description.ToLower()} {artistsString} for {userTitle}");
+            if (!userSettings.DifferentUser)
+            {
+                this._embedAuthor.WithIconUrl(this.Context.User.GetAvatarUrl());
+            }
+            this._embedAuthor.WithName($"Top {timeSettings.Description.ToLower()} albums for {userTitle}");
             this._embedAuthor.WithUrl($"{Constants.LastFMUserUrl}{userSettings.UserNameLastFm}/library/albums?{timeSettings.UrlParameter}");
 
-            amount = paginationEnabled ? 100 : amount;
+            const int amount = 200;
 
             try
             {
-                var description = "";
                 if (!timeSettings.UsePlays)
                 {
                     var albums = await this._lastFmRepository.GetTopAlbumsAsync(userSettings.UserNameLastFm, timeSettings.TimePeriod, amount);
@@ -435,27 +426,14 @@ namespace FMBot.Bot.Commands.LastFM
                         return;
                     }
 
-                    if (albums.Content.TotalAmount <= 10)
-                    {
-                        paginationEnabled = false;
-                    }
-                    var footer = $"{albums.Content.TotalAmount} different albums in this time period";
+                    var albumPages = albums.Content.TopAlbums.ChunkBy(10);
 
-                    var rnd = new Random();
-                    if (rnd.Next(0, 2) == 1 && albums.Content.TopAlbums.Count > 10 && !paginationEnabled)
+                    var counter = 1;
+                    var pageCounter = 1;
+                    foreach (var albumPage in albumPages)
                     {
-                        footer += $"\nWant pagination? Enable the 'Manage Messages' permission for .fmbot.";
-                    }
-
-                    for (var i = 0; i < albums.Content.TopAlbums.Count; i++)
-                    {
-                        var album = albums.Content.TopAlbums[i];
-
-                        if (albums.Content.TopAlbums.Count > 10 && !paginationEnabled)
-                        {
-                            description += $"{i + 1}. **{album.ArtistName}** - **{album.AlbumName}** ({album.UserPlaycount}  {StringExtensions.GetPlaysString(album.UserPlaycount)}) \n";
-                        }
-                        else
+                        var albumPageString = new StringBuilder();
+                        foreach (var album in albumPage)
                         {
                             var url = album.AlbumUrl;
                             var escapedAlbumName = Regex.Replace(album.AlbumName, @"([|\\*])", @"\$1");
@@ -465,18 +443,18 @@ namespace FMBot.Bot.Commands.LastFM
                                 url = StringExtensions.GetRymUrl(album.AlbumName, album.ArtistName);
                             }
 
-                            description += $"{i + 1}. **{album.ArtistName}** - **[{escapedAlbumName}]({url})** ({album.UserPlaycount}  {StringExtensions.GetPlaysString(album.UserPlaycount)}) \n";
+                            albumPageString.AppendLine($"{counter}. **{album.ArtistName}** - **[{escapedAlbumName}]({url})** ({album.UserPlaycount} {StringExtensions.GetPlaysString(album.UserPlaycount)})");
+                            counter++;
                         }
 
-                        var pageAmount = i + 1;
-                        if (paginationEnabled && (pageAmount > 0 && pageAmount % 10 == 0 || pageAmount == amount))
-                        {
-                            pages.Add(new PageBuilder().WithDescription(description).WithAuthor(this._embedAuthor).WithFooter(footer));
-                            description = "";
-                        }
+                        var footer = $"Page {pageCounter}/{albumPages.Count} - {albums.Content.TotalAmount} different albums in this time period";
+
+                        pages.Add(new PageBuilder()
+                            .WithDescription(albumPageString.ToString())
+                            .WithAuthor(this._embedAuthor)
+                            .WithFooter(footer));
+                        pageCounter++;
                     }
-
-                    this._embedFooter.WithText(footer);
                 }
                 else
                 {
@@ -512,51 +490,42 @@ namespace FMBot.Bot.Commands.LastFM
                     var albums = await this._playService.GetTopAlbums(userId,
                         timeSettings.PlayDays.GetValueOrDefault());
 
-                    if (albums.Count <= 10)
+                    var albumPages = albums.ChunkBy(10);
+
+                    var counter = 1;
+                    var pageCounter = 1;
+                    foreach (var albumPage in albumPages)
                     {
-                        paginationEnabled = false;
-                    }
-
-                    var footer = $"{albums.Count} different albums in this time period";
-
-                    var amountAvailable = albums.Count < amount ? albums.Count : amount;
-                    for (var i = 0; i < amountAvailable; i++)
-                    {
-                        var album = albums[i];
-                        description += $"{i + 1}. **{album.ArtistName}** - **{album.Name}** ({album.Playcount} {StringExtensions.GetPlaysString(album.Playcount)}) \n";
-
-                        var pageAmount = i + 1;
-                        if (paginationEnabled && (pageAmount > 0 && pageAmount % 10 == 0 || pageAmount == amount))
+                        var albumPageString = new StringBuilder();
+                        foreach (var album in albumPage)
                         {
-                            pages.Add(new PageBuilder().WithDescription(description).WithAuthor(this._embedAuthor).WithFooter(footer));
-                            description = "";
+                            albumPageString.AppendLine($"{counter}. **{album.ArtistName}** - **{album.Name}** ({album.Playcount} {StringExtensions.GetPlaysString(album.Playcount)})");
+                            counter++;
                         }
+
+                        var footer = $"Page {pageCounter}/{albumPages.Count} - {albums.Count} different albums in this time period";
+
+                        pages.Add(new PageBuilder()
+                            .WithDescription(albumPageString.ToString())
+                            .WithAuthor(this._embedAuthor)
+                            .WithFooter(footer));
+                        pageCounter++;
                     }
-
-                    this._embedFooter.WithText(footer);
                 }
 
-                if (paginationEnabled)
+                if (!pages.Any())
                 {
-                    var paginator = new StaticPaginatorBuilder()
-                        .WithPages(pages)
-                        .WithFooter(PaginatorFooter.PageNumber)
-                        .WithEmotes(DiscordConstants.PaginationEmotes)
-                        .WithTimoutedEmbed(null)
-                        .WithCancelledEmbed(null)
-                        .WithDeletion(DeletionOptions.Valid)
-                        .Build();
-
-                    _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds), runOnGateway: false);
+                    pages.Add(new PageBuilder()
+                        .WithDescription("No albums played in this time period.")
+                        .WithAuthor(this._embedAuthor));
                 }
-                else
-                {
-                    this._embed.WithAuthor(this._embedAuthor);
-                    this._embed.WithDescription(description);
-                    this._embed.WithFooter(this._embedFooter);
 
-                    await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-                }
+                var paginator = StringService.BuildStaticPaginator(pages);
+
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
 
                 this.Context.LogCommandUsed();
             }
@@ -708,7 +677,7 @@ namespace FMBot.Bot.Commands.LastFM
         [Command("globalwhoknowsalbum", RunMode = RunMode.Async)]
         [Summary("Shows what other users listen to the an album on .fmbot")]
         [Examples("gwa", "globalwhoknowsalbum", "globalwhoknowsalbum the beatles abbey road", "globalwhoknowsalbum Metallica & Lou Reed | Lulu")]
-        [Alias("gwa", "gwka", "gwab", "gwkab", "globalwhoknows album")]
+        [Alias("gwa", "gwka", "gwab", "gwkab", "globalwka", "globalwkalbum", "globalwhoknows album")]
         [UsernameSetRequired]
         [GuildOnly]
         [RequiresIndex]

--- a/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/AlbumCommands.cs
@@ -525,7 +525,8 @@ namespace FMBot.Bot.Commands.LastFM
                 _ = this.Interactivity.SendPaginatorAsync(
                     paginator,
                     this.Context.Channel,
-                    TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }

--- a/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ArtistCommands.cs
@@ -287,7 +287,11 @@ namespace FMBot.Bot.Commands.LastFM
 
             var paginator = StringService.BuildStaticPaginator(pages);
 
-            _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds));
+            _ = this.Interactivity.SendPaginatorAsync(
+                paginator,
+                this.Context.Channel,
+                TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                resetTimeoutOnInput: true);
 
             this.Context.LogCommandUsed();
         }
@@ -356,7 +360,11 @@ namespace FMBot.Bot.Commands.LastFM
 
             var paginator = StringService.BuildStaticPaginator(pages);
 
-            _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+            _ = this.Interactivity.SendPaginatorAsync(
+                paginator,
+                this.Context.Channel,
+                TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                resetTimeoutOnInput: true);
 
             await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
             this.Context.LogCommandUsed();
@@ -526,7 +534,11 @@ namespace FMBot.Bot.Commands.LastFM
 
                 var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }

--- a/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/ChartCommands.cs
@@ -165,6 +165,21 @@ namespace FMBot.Bot.Commands.LastFM
 
                 topAlbums = await this._albumService.FillMissingAlbumCovers(topAlbums);
 
+                var albumWithoutImage = topAlbums.FirstOrDefault(f => f.AlbumCoverUrl == null);
+                if (albumWithoutImage != null)
+                {
+                    var albumCall = await this._lastFmRepository.GetAlbumInfoAsync(albumWithoutImage.ArtistName, albumWithoutImage.AlbumName, userSettings.UserNameLastFm);
+                    if (albumCall.Success && albumCall.Content != null)
+                    {
+                        var spotifyArtistImage = await this._spotifyService.GetOrStoreSpotifyAlbumAsync(albumCall.Content);
+                        if (spotifyArtistImage?.SpotifyImageUrl != null)
+                        {
+                            var index = topAlbums.FindIndex(f => f.ArtistName == albumWithoutImage.ArtistName);
+                            topAlbums[index].AlbumCoverUrl = spotifyArtistImage.SpotifyImageUrl;
+                        }
+                    }
+                }
+
                 chartSettings.Albums = topAlbums;
 
                 var embedAuthorDescription = "";

--- a/src/FMBot.Bot/Commands/LastFM/CrownCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/CrownCommands.cs
@@ -1,14 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
-using Discord;
 using Discord.Commands;
+using Fergun.Interactive;
 using FMBot.Bot.Attributes;
-using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
@@ -18,8 +16,6 @@ using FMBot.Bot.Services.WhoKnows;
 using FMBot.Domain;
 using FMBot.Domain.Models;
 using FMBot.LastFM.Repositories;
-using Interactivity;
-using Interactivity.Pagination;
 using Microsoft.Extensions.Options;
 
 namespace FMBot.Bot.Commands.LastFM
@@ -35,7 +31,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly SettingService _settingService;
         private readonly UserService _userService;
 
-        private InteractivityService Interactivity { get; }
+        private InteractiveService Interactivity { get; }
 
         public CrownCommands(CrownService crownService,
             GuildService guildService,
@@ -44,7 +40,7 @@ namespace FMBot.Bot.Commands.LastFM
             AdminService adminService,
             LastFmRepository lastFmRepository,
             SettingService settingService,
-            InteractivityService interactivity,
+            InteractiveService interactivity,
             IOptions<BotSettings> botSettings) : base(botSettings)
         {
             this._crownService = crownService;
@@ -107,59 +103,35 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var footer = $"{userCrowns.Count} total crowns";
-
             try
             {
-                var paginationEnabled = false;
-                var maxAmount = userCrowns.Count > 15 ? 15 : userCrowns.Count;
                 var pages = new List<PageBuilder>();
-                var perms = await GuildService.GetGuildPermissionsAsync(this.Context);
-                if (perms.ManageMessages && userCrowns.Count > 15)
+
+                var crownPages = userCrowns.ChunkBy(10);
+
+                var counter = 1;
+                var pageCounter = 1;
+                foreach (var crownPage in crownPages)
                 {
-                    paginationEnabled = true;
-                    maxAmount = userCrowns.Count;
-                }
-
-                var embedDescription = new StringBuilder();
-                for (var index = 0; index < maxAmount; index++)
-                {
-                    var userCrown = userCrowns[index];
-
-                    var specifiedDateTime = DateTime.SpecifyKind(userCrown.Created, DateTimeKind.Utc);
-                    var dateValue = ((DateTimeOffset)specifiedDateTime).ToUnixTimeSeconds();
-
-                    embedDescription.AppendLine($"{index + 1}. **{userCrown.ArtistName}** - **{userCrown.CurrentPlaycount}** plays (claimed <t:{((DateTimeOffset)userCrown.Created).ToUnixTimeSeconds()}:R>)");
-
-                    var pageAmount = index + 1;
-                    if (paginationEnabled && (pageAmount > 0 && pageAmount % 10 == 0 || pageAmount == maxAmount))
+                    var crownPageString = new StringBuilder();
+                    foreach (var userCrown in crownPage)
                     {
-                        pages.Add(new PageBuilder().WithDescription(embedDescription.ToString()).WithTitle(title).WithFooter(footer));
-                        embedDescription = new StringBuilder();
+                        crownPageString.AppendLine($"{counter}. **{userCrown.ArtistName}** - **{userCrown.CurrentPlaycount}** plays (claimed <t:{((DateTimeOffset)userCrown.Created).ToUnixTimeSeconds()}:R>)");
+                        counter++;
                     }
+
+                    var footer = $"Page {pageCounter}/{crownPages.Count} - {userCrowns.Count} total crowns";
+
+                    pages.Add(new PageBuilder()
+                        .WithDescription(crownPageString.ToString())
+                        .WithTitle(title)
+                        .WithFooter(footer));
+                    pageCounter++;
                 }
 
-                if (paginationEnabled)
-                {
-                    var paginator = new StaticPaginatorBuilder()
-                        .WithPages(pages)
-                        .WithFooter(PaginatorFooter.PageNumber)
-                        .WithEmotes(DiscordConstants.PaginationEmotes)
-                        .WithTimoutedEmbed(null)
-                        .WithCancelledEmbed(null)
-                        .WithDeletion(DeletionOptions.Valid)
-                        .Build();
+                var paginator = StringService.BuildStaticPaginator(pages);
 
-                    _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds), runOnGateway: false);
-                }
-                else
-                {
-                    footer += "\nWant pagination? Enable the 'Manage Messages' permission for .fmbot.";
-                    this._embed.WithTitle(title);
-                    this._embed.WithDescription(embedDescription.ToString());
-                    this._embed.WithFooter(footer);
-                    await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-                }
+                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
             }
             catch (Exception e)
             {
@@ -306,70 +278,46 @@ namespace FMBot.Bot.Commands.LastFM
                 return;
             }
 
-            var paginationEnabled = false;
-            var maxAmount = topCrownUsers.Count > 15 ? 15 : topCrownUsers.Count;
             var pages = new List<PageBuilder>();
-            var perms = await GuildService.GetGuildPermissionsAsync(this.Context);
-            if (perms.ManageMessages && topCrownUsers.Count > 15)
-            {
-                paginationEnabled = true;
-                maxAmount = topCrownUsers.Count;
-            }
 
             var title = $"Users with most crowns in {this.Context.Guild.Name}";
-            var embedDescription = new StringBuilder();
-            var footer = $"{guildCrownCount} total active crowns in this server";
 
-            if (topCrownUsers.Count < 15)
+            var crownPages = topCrownUsers.ChunkBy(10);
+
+            var counter = 1;
+            var pageCounter = 1;
+            foreach (var crownPage in crownPages)
             {
-                paginationEnabled = false;
-            }
-
-            for (var index = 0; index < maxAmount; index++)
-            {
-                var crownUser = topCrownUsers[index];
-
-                var guildUser = guild
-                    .GuildUsers
-                    .FirstOrDefault(f => f.UserId == crownUser.Key);
-
-                string name = null;
-
-                if (guildUser != null)
+                var crownPageString = new StringBuilder();
+                foreach (var crownUser in crownPage)
                 {
-                    name = guildUser.UserName;
+                    var guildUser = guild
+                        .GuildUsers
+                        .FirstOrDefault(f => f.UserId == crownUser.Key);
+
+                    string name = null;
+
+                    if (guildUser != null)
+                    {
+                        name = guildUser.UserName;
+                    }
+
+                    crownPageString.AppendLine($"{counter}. **{name ?? crownUser.First().User.UserNameLastFM}** - **{crownUser.Count()}** {StringExtensions.GetCrownsString(crownUser.Count())}");
+                    counter++;
                 }
 
-                embedDescription.AppendLine($"{index + 1}. **{name ?? crownUser.First().User.UserNameLastFM}** - **{crownUser.Count()}** {StringExtensions.GetCrownsString(crownUser.Count())}");
+                var footer = $"Page {pageCounter}/{crownPages.Count} - {guildCrownCount} total active crowns in this server";
 
-                var pageAmount = index + 1;
-                if (paginationEnabled && (pageAmount > 0 && pageAmount % 10 == 0 || pageAmount == maxAmount))
-                {
-                    pages.Add(new PageBuilder().WithDescription(embedDescription.ToString()).WithTitle(title).WithFooter(footer));
-                    embedDescription = new StringBuilder();
-                }
+                pages.Add(new PageBuilder()
+                    .WithDescription(crownPageString.ToString())
+                    .WithTitle(title)
+                    .WithFooter(footer));
+                pageCounter++;
             }
 
-            if (paginationEnabled)
-            {
-                var paginator = new StaticPaginatorBuilder()
-                    .WithPages(pages)
-                    .WithFooter(PaginatorFooter.PageNumber)
-                    .WithEmotes(DiscordConstants.PaginationEmotes)
-                    .WithTimoutedEmbed(null)
-                    .WithCancelledEmbed(null)
-                    .WithDeletion(DeletionOptions.Valid)
-                    .Build();
+            var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds), runOnGateway: false);
-            }
-            else
-            {
-                this._embed.WithTitle(title);
-                this._embed.WithDescription(embedDescription.ToString());
-                this._embed.WithFooter(footer);
-                await this.Context.Channel.SendMessageAsync("", false, this._embed.Build());
-            }
+            _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
 
             this.Context.LogCommandUsed();
         }

--- a/src/FMBot.Bot/Commands/LastFM/CrownCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/CrownCommands.cs
@@ -131,7 +131,11 @@ namespace FMBot.Bot.Commands.LastFM
 
                 var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
             }
             catch (Exception e)
             {
@@ -317,7 +321,11 @@ namespace FMBot.Bot.Commands.LastFM
 
             var paginator = StringService.BuildStaticPaginator(pages);
 
-            _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+            _ = this.Interactivity.SendPaginatorAsync(
+                paginator,
+                this.Context.Channel,
+                TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                resetTimeoutOnInput: true);
 
             this.Context.LogCommandUsed();
         }

--- a/src/FMBot.Bot/Commands/LastFM/GenreCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/GenreCommands.cs
@@ -162,7 +162,11 @@ namespace FMBot.Bot.Commands.LastFM
 
                 var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }
@@ -312,7 +316,7 @@ namespace FMBot.Bot.Commands.LastFM
                     var genrePageString = new StringBuilder();
                     foreach (var genreArtist in genrePage)
                     {
-                        genrePageString.AppendLine($"{counter}. **{genreArtist.ArtistName}** ({genreArtist.UserPlaycount} {StringExtensions.GetPlaysString(genreArtist.UserPlaycount)}");
+                        genrePageString.AppendLine($"{counter}. **{genreArtist.ArtistName}** ({genreArtist.UserPlaycount} {StringExtensions.GetPlaysString(genreArtist.UserPlaycount)})");
                         counter++;
                     }
 
@@ -328,7 +332,11 @@ namespace FMBot.Bot.Commands.LastFM
 
                 var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }

--- a/src/FMBot.Bot/Commands/LastFM/PlayCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/PlayCommands.cs
@@ -1,14 +1,13 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+using Fergun.Interactive;
 using FMBot.Bot.Attributes;
-using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Resources;
@@ -20,8 +19,6 @@ using FMBot.Domain;
 using FMBot.Domain.Models;
 using FMBot.LastFM.Domain.Types;
 using FMBot.LastFM.Repositories;
-using Humanizer;
-using Interactivity;
 using Microsoft.Extensions.Options;
 using Swan;
 using StringExtensions = FMBot.Bot.Extensions.StringExtensions;
@@ -45,7 +42,7 @@ namespace FMBot.Bot.Commands.LastFM
         private readonly WhoKnowsArtistService _whoKnowsArtistService;
         private readonly WhoKnowsAlbumService _whoKnowsAlbumService;
         private readonly WhoKnowsTrackService _whoKnowsTrackService;
-        private InteractivityService Interactivity { get; }
+        private InteractiveService Interactivity { get; }
 
         private static readonly List<DateTimeOffset> StackCooldownTimer = new();
         private static readonly List<SocketUser> StackCooldownTarget = new();
@@ -65,7 +62,7 @@ namespace FMBot.Bot.Commands.LastFM
                 WhoKnowsArtistService whoKnowsArtistService,
                 WhoKnowsAlbumService whoKnowsAlbumService,
                 WhoKnowsTrackService whoKnowsTrackService,
-                InteractivityService interactivity,
+                InteractiveService interactivity,
                 IOptions<BotSettings> botSettings) : base(botSettings)
         {
             this._guildService = guildService;
@@ -147,7 +144,7 @@ namespace FMBot.Bot.Commands.LastFM
                                 .AddSeconds(existingFmCooldown.Value) - DateTimeOffset.Now).TotalSeconds;
                             if (secondsLeft <= existingFmCooldown.Value - 2)
                             {
-                                this.Interactivity.DelayedDeleteMessageAsync(
+                                _ = this.Interactivity.DelayedDeleteMessageAsync(
                                     await this.Context.Channel.SendMessageAsync($"This channel has a `{existingFmCooldown.Value}` second cooldown on `.fm`. Please wait for this to expire before using this command again."),
                                     TimeSpan.FromSeconds(6));
                                 this.Context.LogCommandUsed(CommandResponse.Cooldown);

--- a/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/TrackCommands.cs
@@ -416,7 +416,8 @@ namespace FMBot.Bot.Commands.LastFM
                 _ = this.Interactivity.SendPaginatorAsync(
                     paginator,
                     this.Context.Channel,
-                    TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }
@@ -655,7 +656,11 @@ namespace FMBot.Bot.Commands.LastFM
 
                 var paginator = StringService.BuildStaticPaginator(pages);
 
-                _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+                _ = this.Interactivity.SendPaginatorAsync(
+                    paginator,
+                    this.Context.Channel,
+                    TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                    resetTimeoutOnInput: true);
 
                 this.Context.LogCommandUsed();
             }

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -245,9 +245,7 @@ namespace FMBot.Bot.Commands.LastFM
                                             "For this to work properly you need to make sure .fmbot can see the voice channel and use a supported music bot.\n\n" +
                                             "Only tracks that already exist on Last.fm will be scrobbled. This feature works best with Spotify music.\n\n" +
                                             "Currently supported bots:\n" +
-                                            "- Groovy (✝️)\n" +
-                                            "- Rythm (Requires setting '[announcesongs](https://rythm.fm/docs/commands#settings)' to be enabled)\n" +
-                                            "- Hydra\n");
+                                            "- Hydra (Only in 'normal' mode)\n");
 
                 if ((newBotScrobblingDisabledSetting == null || newBotScrobblingDisabledSetting == false) && !string.IsNullOrWhiteSpace(user.SessionKeyLastFm))
                 {

--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -508,7 +508,7 @@ namespace FMBot.Bot.Commands.LastFM
         [Command("login", RunMode = RunMode.Async)]
         [Summary("Logs you in using a link.\n\n" +
                  "Not receiving a DM? Please check if you have direct messages from server members enabled.")]
-        [Alias("set", "setusername", "fm set")]
+        [Alias("set", "setusername", "fm set", "connect")]
         public async Task LoginAsync([Remainder] string unusedValues = null)
         {
             var prfx = this._prefixService.GetPrefix(this.Context.Guild?.Id);
@@ -553,6 +553,9 @@ namespace FMBot.Bot.Commands.LastFM
 
             if (!this._guildService.CheckIfDM(this.Context))
             {
+                var serverEmbed = new EmbedBuilder()
+                    .WithColor(DiscordConstants.InformationColorBlue);
+
                 var reply = "Check your DMs for a link to connect your Last.fm account to .fmbot!";
 
                 if (this.Context.Message.Content.Contains("set"))
@@ -560,7 +563,15 @@ namespace FMBot.Bot.Commands.LastFM
                     reply += $"\nPlease use `{prfx}mode` to change how your .fm command looks.";
                 }
 
-                await ReplyAsync(reply);
+                if (existingUserSettings != null)
+                {
+                    reply = $"You have already logged in before, however a link to re-connect your Last.fm account to .fmbot has still been sent to your DMs!\n\n" +
+                            $"Note that .fmbot is not affiliated with Last.fm and/or [Spotify](https://fmbot.xyz/faq/#commands-are-showing-the-wrong-songs-its-not-showing-what-i-listen-to-on-spotify). " +
+                            $"This means that re-logging in will not fix any issues related to those applications.";
+                }
+
+                serverEmbed.WithDescription(reply);
+                await this.Context.Channel.SendMessageAsync("", false, serverEmbed.Build());
             }
 
             var success = await GetAndStoreAuthSession(this.Context.User, token.Content.Token);

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -312,13 +312,15 @@ namespace FMBot.Bot.Commands
         [Alias("donators", "donors", "backers")]
         public async Task AllSupportersAsync()
         {
+            var prefix = this._prefixService.GetPrefix(this.Context.Guild?.Id);
+
             var supporters = await this._supporterService.GetAllVisibleSupporters();
 
             var supporterLists = supporters.ChunkBy(10);
 
             var description = new StringBuilder();
             description.AppendLine("Thank you to all our supporters that help keep .fmbot running. If you would like to be on this list too, please check out our [OpenCollective](https://opencollective.com/fmbot). \n" +
-                                   $"For all information on donating to .fmbot you can check out `.fmdonate`.");
+                                   $"For all information on donating to .fmbot you can check out `{prefix}donate`.");
             description.AppendLine();
 
             var pages = new List<PageBuilder>();

--- a/src/FMBot.Bot/Commands/StaticCommands.cs
+++ b/src/FMBot.Bot/Commands/StaticCommands.cs
@@ -352,7 +352,12 @@ namespace FMBot.Bot.Commands
 
             var paginator = StringService.BuildStaticPaginator(pages);
 
-            _ = this.Interactivity.SendPaginatorAsync(paginator, this.Context.Channel, TimeSpan.FromSeconds(DiscordConstants.PaginationTimeoutInSeconds));
+            _ = this.Interactivity.SendPaginatorAsync(
+                paginator,
+                this.Context.Channel,
+                TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds),
+                resetTimeoutOnInput: true);
+
             this.Context.LogCommandUsed();
         }
 

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="AsyncEnumerator" Version="4.0.2" />
     <PackageReference Include="BotListAPI" Version="5.5.2" />
     <PackageReference Include="Dapper" Version="2.0.90" />
-    <PackageReference Include="Discord.InteractivityAddon.Labs" Version="2.4.1-labs-20210709.1" />
     <PackageReference Include="Discord.Net.Labs" Version="3.0.2" />
     <PackageReference Include="Discord.Net.Labs.Core" Version="3.0.1" />
     <PackageReference Include="Discord.Net.Labs.WebSocket" Version="3.0.2" />
+    <PackageReference Include="Fergun.Interactive.Labs" Version="1.1.0" />
     <PackageReference Include="Genius.NET" Version="4.0.1" />
     <PackageReference Include="Google.Apis" Version="1.52.0" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.52.0.2378" />

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+using Fergun.Interactive;
 using FMBot.Bot.Attributes;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Extensions;
@@ -26,6 +27,7 @@ namespace FMBot.Bot.Handlers
         private readonly MusicBotService _musicBotService;
         private readonly GuildService _guildService;
         private readonly IPrefixService _prefixService;
+        private readonly InteractiveService _interactiveService;
         private readonly IGuildDisabledCommandService _guildDisabledCommandService;
         private readonly IChannelDisabledCommandService _channelDisabledCommandService;
         private readonly IServiceProvider _provider;
@@ -42,7 +44,8 @@ namespace FMBot.Bot.Handlers
             UserService userService,
             MusicBotService musicBotService,
             IOptions<BotSettings> botSettings,
-            GuildService guildService)
+            GuildService guildService,
+            InteractiveService interactiveService)
         {
             this._discord = discord;
             this._commands = commands;
@@ -53,6 +56,7 @@ namespace FMBot.Bot.Handlers
             this._userService = userService;
             this._musicBotService = musicBotService;
             this._guildService = guildService;
+            this._interactiveService = interactiveService;
             this._botSettings = botSettings.Value;
             this._discord.MessageReceived += OnMessageReceivedAsync;
         }
@@ -149,7 +153,9 @@ namespace FMBot.Bot.Handlers
                     disabledGuildCommands != null &&
                     disabledGuildCommands.Any(searchResult.Commands[0].Command.Name.Contains))
                 {
-                    await context.Channel.SendMessageAsync("The command you're trying to execute has been disabled in this server.");
+                    _ = this._interactiveService.DelayedDeleteMessageAsync(
+                        await context.Channel.SendMessageAsync("The command you're trying to execute has been disabled in this server."),
+                        TimeSpan.FromSeconds(8));
                     return;
                 }
 
@@ -160,7 +166,9 @@ namespace FMBot.Bot.Handlers
                     disabledChannelCommands.Any(searchResult.Commands[0].Command.Name.Contains) &&
                     context.Channel != null)
                 {
-                    await context.Channel.SendMessageAsync("The command you're trying to execute has been disabled in this channel.");
+                    _ = this._interactiveService.DelayedDeleteMessageAsync(
+                        await context.Channel.SendMessageAsync("The command you're trying to execute has been disabled in this channel."),
+                        TimeSpan.FromSeconds(8));
                     return;
                 }
             }

--- a/src/FMBot.Bot/Models/ArtistModels.cs
+++ b/src/FMBot.Bot/Models/ArtistModels.cs
@@ -9,6 +9,8 @@ namespace FMBot.Bot.Models
 
         public TimePeriod ChartTimePeriod { get; set; }
 
+        public string TimeDescription { get; set; }
+
         public int AmountOfDays { get; set; }
     }
 

--- a/src/FMBot.Bot/Resources/DiscordConstants.cs
+++ b/src/FMBot.Bot/Resources/DiscordConstants.cs
@@ -19,7 +19,7 @@ namespace FMBot.Bot.Resources
 
         public static readonly IDictionary<IEmote, PaginatorAction> PaginationEmotes = new Dictionary<IEmote, PaginatorAction>
         {
-            { Emote.Parse("<:pagesfirst:883825508633182208>"), PaginatorAction.SkipToStart},
+            { Emote.Parse("<:pages_first:883825508633182208>"), PaginatorAction.SkipToStart},
             { Emote.Parse("<:pages_previous:883825508507336704>"), PaginatorAction.Backward},
             { Emote.Parse("<:pages_next:883825508087922739>"), PaginatorAction.Forward},
             { Emote.Parse("<:pages_last:883825508482183258>"), PaginatorAction.SkipToEnd}

--- a/src/FMBot.Bot/Resources/DiscordConstants.cs
+++ b/src/FMBot.Bot/Resources/DiscordConstants.cs
@@ -1,6 +1,6 @@
 using System.Collections.Generic;
 using Discord;
-using Interactivity.Pagination;
+using Fergun.Interactive.Pagination;
 
 namespace FMBot.Bot.Resources
 {
@@ -17,12 +17,12 @@ namespace FMBot.Bot.Resources
 
         public static Color SpotifyColorGreen = new(30, 215, 97);
 
-        public static readonly Dictionary<IEmote, PaginatorAction> PaginationEmotes = new()
+        public static readonly IDictionary<IEmote, PaginatorAction> PaginationEmotes = new Dictionary<IEmote, PaginatorAction>
         {
-            { new Emoji("⏮️"), PaginatorAction.SkipToStart},
-            { new Emoji("⬅️"), PaginatorAction.Backward},
-            { new Emoji("➡️"), PaginatorAction.Forward},
-            { new Emoji("⏭️"), PaginatorAction.SkipToEnd}
+            { Emote.Parse("<:pagesfirst:883825508633182208>"), PaginatorAction.SkipToStart},
+            { Emote.Parse("<:pages_previous:883825508507336704>"), PaginatorAction.Backward},
+            { Emote.Parse("<:pages_next:883825508087922739>"), PaginatorAction.Forward},
+            { Emote.Parse("<:pages_last:883825508482183258>"), PaginatorAction.SkipToEnd}
         };
 
         public const int PaginationTimeoutInSeconds = 120;

--- a/src/FMBot.Bot/Resources/DiscordConstants.cs
+++ b/src/FMBot.Bot/Resources/DiscordConstants.cs
@@ -25,6 +25,6 @@ namespace FMBot.Bot.Resources
             { Emote.Parse("<:pages_last:883825508482183258>"), PaginatorAction.SkipToEnd}
         };
 
-        public const int PaginationTimeoutInSeconds = 120;
+        public const int PaginationTimeoutInSeconds = 60;
     }
 }

--- a/src/FMBot.Bot/Services/GenericEmbedService.cs
+++ b/src/FMBot.Bot/Services/GenericEmbedService.cs
@@ -52,40 +52,13 @@ namespace FMBot.Bot.Services
             embed.WithColor(DiscordConstants.WarningColorOrange);
         }
 
-        public static void NoScrobblesFoundErrorResponse(this EmbedBuilder embed, LastResponseStatus? apiResponse, string prfx, string userName)
-        {
-            switch (apiResponse)
-            {
-                case LastResponseStatus.Failure:
-                    embed.WithTitle("Error while attempting get Last.fm information");
-                    embed.WithDescription(
-                        "Can't retrieve scrobbles because Last.fm is having issues. Please try again later. \n" +
-                        "Please note that .fmbot isn't affiliated with Last.fm.");
-                    break;
-                case LastResponseStatus.MissingParameters:
-                    embed.WithTitle("Error while attempting get Last.fm information");
-                    embed.WithDescription(
-                        "You or the user you're searching for has no scrobbles/artists on their profile, or Last.fm is having issues. Please try again later. \n \n" +
-                        $"Recently changed your Last.fm username? Please change it here too using `{prfx}login` again.");
-                    break;
-                default:
-                    embed.WithDescription(
-                        $"The Last.fm user `{userName}` has no scrobbles/artists/albums/tracks on [their profile]({Constants.LastFMUserUrl}{userName}).\n\n" +
-                        $"Just signed up for last.fm and added your account in the bot? Make sure you [track your music](https://www.last.fm/about/trackmymusic) and your Last.fm profile is showing the music that you're listening to.");
-                    break;
-            }
-
-            embed.WithThumbnailUrl("https://www.last.fm/static/images/marvin.e51495403de9.png");
-            embed.WithColor(DiscordConstants.WarningColorOrange);
-        }
-
         private static void NoScrobblesFoundErrorResponse(this EmbedBuilder embed, string userName)
         {
-            embed.WithTitle("Error while attempting get Last.fm information");
-
-            embed.WithDescription($"The Last.fm user `{userName}` has no scrobbles/artists/albums/tracks on [their Last.fm profile]({Constants.LastFMUserUrl}{userName}).\n\n" +
+            embed.WithDescription($"The Last.fm user `{userName}` has no scrobbles/artists/albums/tracks on [their Last.fm profile]({Constants.LastFMUserUrl}{userName}) yet.\n\n" +
                                   $"Just signed up for last.fm and added your account in the bot? Make sure you properly [track your plays](https://www.last.fm/about/trackmymusic) " +
-                                  $"and your [Last.fm profile]({Constants.LastFMUserUrl}{userName}) is showing the music that you're listening to.");
+                                  $"and your [Last.fm profile]({Constants.LastFMUserUrl}{userName}) is showing the music that you're listening to. \n" +
+                                  $"Usually it takes a few minutes before Last.fm starts working with Spotify after connecting.\n\n" +
+                                  $"Please note that .fmbot is **not** affiliated with Last.fm or Spotify.");
 
             embed.WithColor(DiscordConstants.WarningColorOrange);
         }

--- a/src/FMBot.Bot/Services/Guild/GuildService.cs
+++ b/src/FMBot.Bot/Services/Guild/GuildService.cs
@@ -753,7 +753,7 @@ namespace FMBot.Bot.Services.Guild
         {
             foreach (var emote in emoteString)
             {
-                if (emote.Length == 2)
+                if (emote.Length is 2 or 3)
                 {
                     try
                     {
@@ -795,7 +795,7 @@ namespace FMBot.Bot.Services.Guild
 
             foreach (var emoteString in dbGuild.EmoteReactions)
             {
-                if (emoteString.Length == 2)
+                if (emoteString.Length is 2 or 3)
                 {
                     var emote = new Emoji(emoteString);
                     await message.AddReactionAsync(emote);

--- a/src/FMBot.Bot/Services/MusicBotService.cs
+++ b/src/FMBot.Bot/Services/MusicBotService.cs
@@ -2,12 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
-using FMBot.Bot.Configurations;
+using Fergun.Interactive;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Interfaces;
 using FMBot.Bot.Models;
@@ -16,7 +15,6 @@ using FMBot.Domain;
 using FMBot.LastFM.Repositories;
 using FMBot.Persistence.Domain.Models;
 using FMBot.Persistence.EntityFrameWork;
-using Interactivity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Serilog;
@@ -31,9 +29,9 @@ namespace FMBot.Bot.Services
         private readonly IMemoryCache _cache;
         private readonly IPrefixService _prefixService;
 
-        private InteractivityService Interactivity { get; }
+        private InteractiveService Interactivity { get; }
 
-        public MusicBotService(IDbContextFactory<FMBotDbContext> contextFactory, LastFmRepository lastFmRepository, TrackService trackService, IMemoryCache cache, InteractivityService interactivity, IPrefixService prefixService)
+        public MusicBotService(IDbContextFactory<FMBotDbContext> contextFactory, LastFmRepository lastFmRepository, TrackService trackService, IMemoryCache cache, InteractiveService interactivity, IPrefixService prefixService)
         {
             this._contextFactory = contextFactory;
             this._lastFmRepository = lastFmRepository;

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -22,6 +22,18 @@ namespace FMBot.Bot.Services
             this._contextFactory = contextFactory;
         }
 
+        public static TimeSettingsModel GetTimePeriod(string[] options,
+            TimePeriod defaultTimePeriod = TimePeriod.Weekly)
+        {
+            var optionsAsString = "";
+            if (options.Any())
+            {
+                optionsAsString = string.Join(" ", options);
+            }
+
+            return GetTimePeriod(optionsAsString, defaultTimePeriod);
+        }
+
         public static TimeSettingsModel GetTimePeriod(string options,
             TimePeriod defaultTimePeriod = TimePeriod.Weekly)
         {
@@ -32,7 +44,7 @@ namespace FMBot.Bot.Services
             settingsModel.NewSearchValue = options;
             settingsModel.UsePlays = false;
 
-            var oneDay = new[] { "1-day", "1day", "1d", "today", "day" };
+            var oneDay = new[] { "1-day", "1day", "1d", "today", "day", "daily" };
             var twoDays = new[] { "2-day", "2day", "2d" };
             var threeDays = new[] { "3-day", "3day", "3d" };
             var fourDays = new[] { "4-day", "4day", "4d" };
@@ -512,20 +524,6 @@ namespace FMBot.Bot.Services
         {
             var setGuildRankingSettings = guildRankingSettings;
 
-            if (extraOptions.Contains("w") || extraOptions.Contains("week") || extraOptions.Contains("weekly") || extraOptions.Contains("7d"))
-            {
-                setGuildRankingSettings.ChartTimePeriod = TimePeriod.Weekly;
-                setGuildRankingSettings.AmountOfDays = 7;
-            }
-            else if (extraOptions.Contains("m") || extraOptions.Contains("month") || extraOptions.Contains("monthly") || extraOptions.Contains("30d"))
-            {
-                setGuildRankingSettings.ChartTimePeriod = TimePeriod.Monthly;
-                setGuildRankingSettings.AmountOfDays = 30;
-            }
-            if (extraOptions.Contains("a") || extraOptions.Contains("at") || extraOptions.Contains("alltime"))
-            {
-                setGuildRankingSettings.ChartTimePeriod = TimePeriod.AllTime;
-            }
             if (extraOptions.Contains("p") || extraOptions.Contains("pc") || extraOptions.Contains("playcount") || extraOptions.Contains("plays"))
             {
                 setGuildRankingSettings.OrderType = OrderType.Playcount;

--- a/src/FMBot.Bot/Services/StringService.cs
+++ b/src/FMBot.Bot/Services/StringService.cs
@@ -1,5 +1,9 @@
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Web;
+using Fergun.Interactive;
+using Fergun.Interactive.Pagination;
+using FMBot.Bot.Resources;
 using FMBot.Domain.Models;
 
 namespace FMBot.Bot.Services
@@ -42,6 +46,21 @@ namespace FMBot.Bot.Services
                    (string.IsNullOrWhiteSpace(track.AlbumName)
                        ? "\n"
                        : $" | *{track.AlbumName}*\n");
+        }
+
+        public static StaticPaginator BuildStaticPaginator(IList<PageBuilder> pages, bool paginationEnabled = true)
+        {
+            var builder = new StaticPaginatorBuilder()
+                .WithPages(pages)
+                .WithFooter(PaginatorFooter.None)
+                .WithActionOnTimeout(ActionOnStop.DeleteInput);
+
+            if (pages.Count != 1)
+            {
+                builder.WithOptions(DiscordConstants.PaginationEmotes);
+            }
+
+            return builder.Build();
         }
     }
 }

--- a/src/FMBot.Bot/Services/SupporterService.cs
+++ b/src/FMBot.Bot/Services/SupporterService.cs
@@ -102,7 +102,7 @@ namespace FMBot.Bot.Services
             return await db.Supporters
                 .AsQueryable()
                 .Where(w => w.VisibleInOverview)
-                .OrderByDescending(o => o.SupporterType)
+                .OrderByDescending(o => o.SupporterId)
                 .ToListAsync();
         }
     }

--- a/src/FMBot.Bot/Services/WhoKnows/CrownService.cs
+++ b/src/FMBot.Bot/Services/WhoKnows/CrownService.cs
@@ -330,7 +330,7 @@ namespace FMBot.Bot.Services.WhoKnows
             await db.SaveChangesAsync();
         }
 
-        public async Task<IList<UserCrown>> GetCrownsForUser(Persistence.Domain.Models.Guild guild, int userId)
+        public async Task<List<UserCrown>> GetCrownsForUser(Persistence.Domain.Models.Guild guild, int userId)
         {
             await using var db = this._contextFactory.CreateDbContext();
             return await db.UserCrowns

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
+using Fergun.Interactive;
 using FMBot.Bot.Configurations;
 using FMBot.Bot.Handlers;
 using FMBot.Bot.Interfaces;
@@ -18,7 +19,6 @@ using FMBot.LastFM.Repositories;
 using FMBot.Persistence.EntityFrameWork;
 using FMBot.Persistence.Repositories;
 using FMBot.Youtube.Services;
-using Interactivity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -119,7 +119,7 @@ namespace FMBot.Bot
                 .AddSingleton<IChannelDisabledCommandService, ChannelDisabledCommandService>()
                 .AddSingleton<IIndexService, IndexService>()
                 .AddSingleton<IPrefixService, PrefixService>()
-                .AddSingleton<InteractivityService>()
+                .AddSingleton<InteractiveService>()
                 .AddSingleton<IUserIndexQueue, UserIndexQueue>()
                 .AddSingleton<IUserUpdateQueue, UserUpdateQueue>()
                 .AddSingleton<PlayService>()
@@ -147,8 +147,7 @@ namespace FMBot.Bot
 
             // These services can only be added after the config is loaded
             services
-                .AddSingleton<InteractivityService>()
-                .AddSingleton(new InteractivityConfig { DefaultTimeout = TimeSpan.FromMinutes(3) }) 
+                .AddSingleton<InteractiveService>()
                 .AddSingleton<IndexRepository>()
                 .AddSingleton<UpdateRepository>()
                 .AddSingleton<IUpdateService, UpdateService>()

--- a/src/FMBot.LastFM/Repositories/LastFmRepository.cs
+++ b/src/FMBot.LastFM/Repositories/LastFmRepository.cs
@@ -518,7 +518,7 @@ namespace FMBot.LastFM.Repositories
                         AlbumCoverUrl = !string.IsNullOrWhiteSpace(albumCall.Content.Album.Image?.FirstOrDefault(a => a.Size == "extralarge")?.Text) &&
                                         !albumCall.Content.Album.Image.First(a => a.Size == "extralarge").Text
                                             .Contains(Constants.LastFmNonExistentImageName)
-                            ? albumCall.Content.Album.Image?.First(a => a.Size == "extralarge").Text
+                            ? albumCall.Content.Album.Image?.First(a => a.Size == "extralarge").Text.Replace("/u/300x300/", "/u/")
                             : null,
                     }
                 };


### PR DESCRIPTION
- Move commands with pagination to new pagination
- Cover command now shows higher resolution cover
- Artist albums now supports pagination
- Server artist/albums/tracks now support day timeperiod
- Top genres are now better sorted and keep in mind the playcounts for artists
- Fix serverreactions not working with certain emotes (including wastebasket emote)
- Improve message for `.login` if you're already logged in
- Source album covers from Spotify for `.chart`
- Other small improvements