### PR TITLE
Fix Love Track not showing embed in some cases

### DIFF
--- a/src/FMBot.LastFM/Repositories/LastFmRepository.cs
+++ b/src/FMBot.LastFM/Repositories/LastFmRepository.cs
@@ -383,8 +383,8 @@ namespace FMBot.LastFM.Repositories
                         AlbumArtist = trackCall.Content.Track.Album?.Artist,
                         AlbumUrl = trackCall.Content.Track.Album?.Url,
                         ArtistName = trackCall.Content.Track.Artist?.Name,
-                        ArtistUrl = Uri.IsWellFormedUriString(trackCall.Content.Track.Artist.Url, UriKind.Absolute)
-                            ? trackCall.Content.Track.Artist.Url
+                        ArtistUrl = Uri.IsWellFormedUriString(trackCall.Content.Track.Artist?.Url, UriKind.Absolute)
+                            ? trackCall.Content.Track.Artist?.Url
                             : null,
                         ArtistMbid = !string.IsNullOrWhiteSpace(trackCall.Content.Track.Artist?.Mbid)
                             ? Guid.Parse(trackCall.Content.Track.Artist?.Mbid)


### PR DESCRIPTION
For certain tracks as shown in https://github.com/fmbot-discord/fmbot/issues/128, the track URL returned is not recognised as a well formed URI by Uri.IsWellFormedUriString. As a result, the Track URL is nulled in the response, causing the call to `ResponseTrackToLinkedString` to fail. As mentioned in the issue, interesting the same URL seems to pass in .NET Framework, but not .NET 5.

This PR guards against null TrackUrls in `ResponseTrackToLinkedString`, returning instead the output from `ResponseTrackToString` so that the response embed is still rendered, without the Track Link:

![image](https://user-images.githubusercontent.com/17815828/137021316-d66e12e4-0043-4c16-9543-a4947a1f85dc.png)


Also fixes the ArtistUrl in the TrackInfo response, which was set to Artist Name instead of Url
