### PR TITLE
SoundCloud bot support + ability to fetch "Now Playing" embeds received after loading message

### DIFF
--- a/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
+++ b/src/FMBot.Bot/Commands/LastFM/UserCommands.cs
@@ -317,7 +317,8 @@ namespace FMBot.Bot.Commands.LastFM
                                             "Only tracks that already exist on Last.fm will be scrobbled. This feature works best with Spotify music.\n\n" +
                                             "Currently supported bots:\n" +
                                             "- Hydra (Only with Now Playing messages enabled in English)\n" +
-                                            "- Cakey Bot (Only with Now Playing messages enabled in English)\n");
+                                            "- Cakey Bot (Only with Now Playing messages enabled in English)\n" +
+                                            "- SoundCloud");
 
                 if ((newBotScrobblingDisabledSetting == null || newBotScrobblingDisabledSetting == false) && !string.IsNullOrWhiteSpace(user.SessionKeyLastFm))
                 {

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -62,6 +62,7 @@ public class CommandHandler
         this._cache = cache;
         this._botSettings = botSettings.Value;
         this._discord.MessageReceived += OnMessageReceivedAsync;
+        this._discord.MessageUpdated += OnMessageUpdatedAsync;
     }
 
     private async Task OnMessageReceivedAsync(SocketMessage s)
@@ -93,6 +94,10 @@ public class CommandHandler
             if (msg.Author.Username.StartsWith("Cakey Bot"))
             {
                 await this._musicBotService.ScrobbleCakeyBot(msg, context);
+            }
+            if (msg.Author.Username.StartsWith("SoundCloud"))
+            {
+                await this._musicBotService.ScrobbleSoundCloud(msg, context);
             }
             return; // Ignore other bots
         }
@@ -136,6 +141,20 @@ public class CommandHandler
             await ExecuteCommand(msg, context, argPos, prfx);
             return;
         }
+    }
+
+    private async Task OnMessageUpdatedAsync(Cacheable<IMessage, ulong> originalMessage, SocketMessage updatedMessage, ISocketMessageChannel sourceChannel)
+    {
+        var msg = updatedMessage as SocketUserMessage;
+
+        if (msg == null || msg.Author == null || !msg.Author.IsBot || msg.Interaction == null)
+            return;
+
+        var context = new ShardedCommandContext(this._discord, msg);
+
+        // Trying to fetch follow-up "Now Playing"
+        if (msg.Author.Username.StartsWith("SoundCloud"))
+            await this._musicBotService.ScrobbleSoundCloud(msg, context);
     }
 
     private async Task ExecuteCommand(SocketUserMessage msg, ShardedCommandContext context, int argPos, string prfx)

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -148,13 +148,17 @@ public class CommandHandler
         var msg = updatedMessage as SocketUserMessage;
 
         if (msg == null || msg.Author == null || !msg.Author.IsBot || msg.Interaction == null)
+        {
             return;
+        }
 
         var context = new ShardedCommandContext(this._discord, msg);
 
         // Trying to fetch follow-up "Now Playing"
         if (msg.Author.Username.StartsWith("SoundCloud"))
+        {
             await this._musicBotService.ScrobbleSoundCloud(msg, context);
+        }
     }
 
     private async Task ExecuteCommand(SocketUserMessage msg, ShardedCommandContext context, int argPos, string prfx)

--- a/src/FMBot.Bot/Services/MusicBotService.cs
+++ b/src/FMBot.Bot/Services/MusicBotService.cs
@@ -148,14 +148,14 @@ public class MusicBotService
 
             // Bot sends only single embed per request
             if (msg.Embeds.Count != 1)
+            {
                 return;
+            }
 
             var targetEmbed = msg.Embeds.First();
 
-            if (
-                !targetEmbed.Title.Contains("Now Playing")
-                || string.IsNullOrEmpty(targetEmbed.Description)
-            )
+            if (!targetEmbed.Title.Contains("Now Playing") ||
+                string.IsNullOrEmpty(targetEmbed.Description))
             {
                 return;
             }
@@ -176,6 +176,7 @@ public class MusicBotService
             {
                 Log.Information("BotScrobbling: Skipped scrobble for {listenerCount} users in {guildName} / {guildId} because no found track for {trackDescription}", usersInChannel.Count, context.Guild.Name, context.Guild.Id, msg.Embeds.First().Description);
                 this.BotScrobblingLogs.Add(new BotScrobblingLog(context.Guild.Id, DateTime.UtcNow, $"Skipped scrobble because no found track for `{msg.Embeds.First().Description}`"));
+
                 return;
             }
 

--- a/src/FMBot.Bot/Services/MusicBotService.cs
+++ b/src/FMBot.Bot/Services/MusicBotService.cs
@@ -154,7 +154,8 @@ public class MusicBotService
 
             var targetEmbed = msg.Embeds.First();
 
-            if (!targetEmbed.Title.Contains("Now Playing") ||
+            if (targetEmbed.Title == null ||
+                !targetEmbed.Title.Contains("Now Playing") ||
                 string.IsNullOrEmpty(targetEmbed.Description))
             {
                 return;


### PR DESCRIPTION
# What's included:
- Scrobbling support for SoundCloud bot (#183)
- Additional tweak for fetching "Now Playing" message returned directly from the `play` commands (enabled for the SoundCloud only)

## Problem with fetching first "Now Playing" message

When slash command for starting the playing is used, music bot will send empty message with `Loading` flag. The actual message with "Now Playing" embed is received after, updating this original empty message.

## Solution

In the PR I just added additional handler for the `MessageUpdated` event inside `CommandHandler` class. This handler is filtering out messages from bots with interaction available and sending them to the `MusicBotService`.

While testing I stumbled upon the fact that `MessageUpdate` event was sending me `SocketWebhookUser` instead of `SocketGuildUser`. So the `MusicBotService.GetUsersInVoice` was unable to return the data about users. I made a workaround for it, requesting the `SocketGuildUser` with `SocketGuild.GetUserAsync` method.

As noted above, this feature is now enabled only for the SoundCloud bot and working fine so far.