### PR TITLE
look beyond country field when the value is null

### DIFF
--- a/src/FMBot.Bot/Extensions/MusicBrainzExtensions.cs
+++ b/src/FMBot.Bot/Extensions/MusicBrainzExtensions.cs
@@ -1,0 +1,23 @@
+using System.Linq;
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
+
+namespace FMBot.Bot.Extensions;
+
+public static class MusicBrainzExtensions
+{
+    #nullable enable
+    public static string? GetCountryCode(
+        this IArtist musicBrainzArtist)
+    {
+        var country = musicBrainzArtist.Country
+                      ?? musicBrainzArtist.Area?.Iso31662Codes?.FirstOrDefault()
+                      ?? musicBrainzArtist.Area?.Iso31661Codes?.FirstOrDefault()
+                      ?? musicBrainzArtist.BeginArea?.Iso31662Codes?.FirstOrDefault()
+                      ?? musicBrainzArtist.BeginArea?.Iso31661Codes?.FirstOrDefault();
+
+        if (country == null) return null;
+        if (country.Contains('-')) return country.Split("-").First();
+
+        return country;
+    }
+}

--- a/src/FMBot.Bot/Services/MusicBrainzService.cs
+++ b/src/FMBot.Bot/Services/MusicBrainzService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FMBot.Bot.Extensions;
 using FMBot.Domain;
 using FMBot.Persistence.Domain.Models;
 using MetaBrainz.MusicBrainz;
@@ -43,7 +44,7 @@ public class MusicBrainzService
 
                     artist.MusicBrainzDate = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
                     artist.Location = musicBrainzArtist.Area?.Name;
-                    artist.CountryCode = musicBrainzArtist.Country;
+                    artist.CountryCode = musicBrainzArtist.GetCountryCode();
                     artist.Type = musicBrainzArtist.Type;
                     artist.Disambiguation = musicBrainzArtist.Disambiguation;
                     artist.Gender = musicBrainzArtist.Gender;
@@ -71,7 +72,7 @@ public class MusicBrainzService
 
                     artist.MusicBrainzDate = DateTime.SpecifyKind(DateTime.UtcNow,DateTimeKind.Utc);
                     artist.Location = musicBrainzArtist.Area?.Name;
-                    artist.CountryCode = musicBrainzArtist.Country;
+                    artist.CountryCode = musicBrainzArtist.GetCountryCode();
                     artist.Type = musicBrainzArtist.Type;
                     artist.Disambiguation = musicBrainzArtist.Disambiguation;
                     artist.Gender = musicBrainzArtist.Gender;


### PR DESCRIPTION
related to this ancient bug: https://tickets.metabrainz.org/browse/MBS-7398
discord discussion: https://discord.com/channels/821660544581763093/1065299133231014019/1065299133231014019

this introduces a MusicBrainz extension function to try and get a country code even if the `country` field in the MusicBrainz API response is not set. the strategy is rather naïve but i still think it should improve commands such as `.from` and `.countries`, and it should be relatively simple to expand on the function if needed.

also beware: i haven't tested this code beyond seeing if it compiles. `CONTRIBUTING.md` seems to imply that this is fine.