### PR TITLE
Ignore user specifier when deciding CrownOrderType

### DIFF
--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -830,6 +830,9 @@ public class SettingService
         return guildRankingSettings;
     }
 
+    /// <param name="extraOptions">
+    ///         the part of the command that comes after ".crowns" (or after an alias of ".crowns"). This should include the user specifier.
+    /// </param>
     public static CrownViewSettings SetCrownViewSettings(CrownViewSettings crownViewSettings, string extraOptions)
     {
         var setCrownViewSettings = crownViewSettings;
@@ -838,12 +841,20 @@ public class SettingService
         {
             return setCrownViewSettings;
         }
+        
+        string[] extraOptionsArray = extraOptions.Split();
+        if (extraOptionsArray.Length == 1) {
+		    return setCrownViewSettings; // No order specifier was included, so use default settings
+	    }
+	
+	    string orderSpecifier = extraOptionsArray[1]; // Remove user specifier from string considered in deciding CrownOrderType.
+							                            // NOTE: This also removes any arguments after the second.
 
-        if (extraOptions.Contains("p") || extraOptions.Contains("pc") || extraOptions.Contains("playcount") || extraOptions.Contains("plays"))
+        if (orderSpecifier.Contains("p") || orderSpecifier.Contains("pc") || orderSpecifier.Contains("playcount") || orderSpecifier.Contains("plays"))
         {
             setCrownViewSettings.CrownOrderType = CrownOrderType.Playcount;
         }
-        if (extraOptions.Contains("r") || extraOptions.Contains("rc") || extraOptions.Contains("recent") || extraOptions.Contains("new") || extraOptions.Contains("latest"))
+        else if (orderSpecifier.Contains("r") || orderSpecifier.Contains("rc") || orderSpecifier.Contains("recent") || orderSpecifier.Contains("new") || orderSpecifier.Contains("latest"))
         {
             setCrownViewSettings.CrownOrderType = CrownOrderType.Recent;
         }

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -830,9 +830,6 @@ public class SettingService
         return guildRankingSettings;
     }
 
-    /// <param name="extraOptions">
-    ///         the part of the command that comes after ".crowns" (or after an alias of ".crowns"). This should include the user specifier.
-    /// </param>
     public static CrownViewSettings SetCrownViewSettings(CrownViewSettings crownViewSettings, string extraOptions)
     {
         var setCrownViewSettings = crownViewSettings;
@@ -841,20 +838,12 @@ public class SettingService
         {
             return setCrownViewSettings;
         }
-        
-        string[] extraOptionsArray = extraOptions.Split();
-        if (extraOptionsArray.Length == 1) {
-		    return setCrownViewSettings; // No order specifier was included, so use default settings
-	    }
-	
-	    string orderSpecifier = extraOptionsArray[1]; // Remove user specifier from string considered in deciding CrownOrderType.
-							                            // NOTE: This also removes any arguments after the second.
 
-        if (orderSpecifier.Contains("p") || orderSpecifier.Contains("pc") || orderSpecifier.Contains("playcount") || orderSpecifier.Contains("plays"))
+        if (extraOptions.Contains("p") || extraOptions.Contains("pc") || extraOptions.Contains("playcount") || extraOptions.Contains("plays"))
         {
             setCrownViewSettings.CrownOrderType = CrownOrderType.Playcount;
         }
-        else if (orderSpecifier.Contains("r") || orderSpecifier.Contains("rc") || orderSpecifier.Contains("recent") || orderSpecifier.Contains("new") || orderSpecifier.Contains("latest"))
+        if (extraOptions.Contains("r") || extraOptions.Contains("rc") || extraOptions.Contains("recent") || extraOptions.Contains("new") || extraOptions.Contains("latest"))
         {
             setCrownViewSettings.CrownOrderType = CrownOrderType.Recent;
         }

--- a/src/FMBot.Bot/TextCommands/LastFM/CrownCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/CrownCommands.cs
@@ -89,7 +89,7 @@ public class CrownCommands : BaseCommandModule
             CrownOrderType = CrownOrderType.Playcount
         };
 
-        crownViewSettings = SettingService.SetCrownViewSettings(crownViewSettings, extraOptions);
+        crownViewSettings = SettingService.SetCrownViewSettings(crownViewSettings, userSettings.NewSearchValue);
         var userCrowns = await this._crownService.GetCrownsForUser(guild, userSettings.UserId, crownViewSettings.CrownOrderType);
 
         var title = userSettings.DifferentUser


### PR DESCRIPTION
Fixes [Issue 213](https://github.com/fmbot-discord/fmbot/issues/213#issue-1572759901).
This solution assumes the string given to SetCrownViewSettings will include the user specifier. I considered removing the user specifier in the caller (CrownCommands.UserCrownsAsync:70), but because the string could be null and SettingService.GetUser (also called by UserCrownsAsync) also expects extraOptions to include everything after the command name, I decided it would be better to keep that convention for extraOptions. Instead, I manually remove the user specifier in SetCrownViewSettings.
I also replace the sequential "if" structures in deciding CrownOrderType with an "if-else" to make it clear we only expect one branch to execute.