### PR TITLE
add discogs option to .topartists

### DIFF
--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -1261,7 +1261,7 @@ public class ArtistBuilders
         {
             var discogsPage = new PageBuilder();
             discogsPage.WithTitle($"Top Discogs comparison - {Format.Sanitize(ownName)} vs {Format.Sanitize(otherName)}");
-            discogsPage.WithUrl($"https://www.discogs.com/user/{otherWithDiscogs.UserDiscogs.Username}/collection");
+            discogsPage.WithUrl($"{Constants.DiscogsUserURL}{otherWithDiscogs.UserDiscogs.Username}/collection");
 
             var ownReleases = await this._discogsService.GetUserCollection(ownWithDiscogs.UserId);
             var otherReleases = await this._discogsService.GetUserCollection(otherWithDiscogs.UserId);

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -1261,7 +1261,7 @@ public class ArtistBuilders
         {
             var discogsPage = new PageBuilder();
             discogsPage.WithTitle($"Top Discogs comparison - {Format.Sanitize(ownName)} vs {Format.Sanitize(otherName)}");
-            discogsPage.WithUrl($"{Constants.DiscogsUserURL}{otherWithDiscogs.UserDiscogs.Username}/collection");
+            discogsPage.WithUrl($"{Constants.DiscogsUserUrl}{otherWithDiscogs.UserDiscogs.Username}/collection");
 
             var ownReleases = await this._discogsService.GetUserCollection(ownWithDiscogs.UserId);
             var otherReleases = await this._discogsService.GetUserCollection(otherWithDiscogs.UserId);

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -7,12 +7,14 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Discord;
 using Fergun.Interactive;
+using FMBot.Bot.Extensions;
 using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.ThirdParty;
 using FMBot.Domain;
 using FMBot.Domain.Models;
+using FMBot.Persistence.Domain.Models;
 
 namespace FMBot.Bot.Builders;
 
@@ -86,7 +88,7 @@ public class DiscogsBuilder
         {
             await this._discogsService.StoreDiscogsAuth(context.ContextUser.UserId, user.Auth, user.Identity);
 
-            response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}](https://www.discogs.com/user/{user.Identity.Username})' has been connected.\n" +
+            response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}]({Constants.DiscogsUserURL}{user.Identity.Username})' has been connected.\n" +
                                         $"Run the `{context.Prefix}collection` command to view your collection.");
             response.CommandResponse = CommandResponse.Ok;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
@@ -125,7 +127,7 @@ public class DiscogsBuilder
             {
                 response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
             }
-            
+
             response.CommandResponse = CommandResponse.UsernameNotSet;
             return response;
         }
@@ -154,7 +156,7 @@ public class DiscogsBuilder
             ? $"Discogs collection for {userTitle}"
             : $"Discogs collection for {userSettings.DisplayName}, requested by {userTitle}");
 
-        response.EmbedAuthor.WithUrl($"https://www.discogs.com/user/{user.UserDiscogs.Username}/collection");
+        response.EmbedAuthor.WithUrl($"{Constants.DiscogsUserURL}{user.UserDiscogs.Username}/collection");
         response.Embed.WithAuthor(response.EmbedAuthor);
 
         var pages = new List<PageBuilder>();
@@ -217,6 +219,126 @@ public class DiscogsBuilder
             pages.Add(new PageBuilder()
                 .WithDescription("No collection could be found or there are no results.")
                 .WithAuthor(response.EmbedAuthor));
+        }
+
+        response.StaticPaginator = StringService.BuildStaticPaginator(pages);
+        response.ResponseType = ResponseType.Paginator;
+        return response;
+    }
+
+    public async Task<ResponseModel> DiscogsTopArtistsAsync(
+        ContextModel context,
+        TopListSettings topListSettings,
+        TimeSettingsModel timeSettings,
+        UserSettingsModel userSettings)
+    {
+        var response = new ResponseModel
+        {
+            ResponseType = ResponseType.Paginator,
+        };
+
+        var user = await this._userService.GetUserWithDiscogs(userSettings.DiscordUserId);
+
+        if (user.UserDiscogs == null)
+        {
+            if (!userSettings.DifferentUser)
+            {
+                response.Embed.WithDescription("To use the top artists commands with Discogs you have to connect a Discogs account.\n\n" +
+                                               $"Use the `{context.Prefix}discogs` command to get started.");
+            }
+            else
+            {
+                response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
+            }
+
+            response.CommandResponse = CommandResponse.UsernameNotSet;
+            return response;
+        }
+
+        if (user.UserDiscogs.ReleasesLastUpdated == null ||
+            user.UserDiscogs.ReleasesLastUpdated <= DateTime.UtcNow.AddHours(-1))
+        {
+            user.UserDiscogs = await this._discogsService.StoreUserReleases(user);
+            user.UserDiscogs = await this._discogsService.UpdateCollectionValue(user.UserId);
+        }
+
+        var pages = new List<PageBuilder>();
+
+        string userTitle;
+        if (!userSettings.DifferentUser)
+        {
+            if (!context.SlashCommand)
+            {
+                response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
+            }
+            userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
+        }
+        else
+        {
+            userTitle =
+                $"{user.UserDiscogs.Username}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
+        }
+        var userUrl =
+            $"{Constants.DiscogsUserURL}{user.UserDiscogs.Username}/collection";
+
+        response.EmbedAuthor.WithName($"Top {timeSettings.Description.ToLower()} Discogs artists for {userTitle}");
+        response.EmbedAuthor.WithUrl(userUrl);
+
+        var topArtists = new Dictionary<String, TopDiscogsArtist>();
+
+        foreach (UserDiscogsReleases item in user.DiscogsReleases)
+        {
+            if (item.DateAdded < timeSettings.StartDateTime || item.DateAdded >= timeSettings.EndDateTime) {
+                continue;
+            }
+            TopDiscogsArtist value = null;
+            if (!topArtists.TryGetValue(item.Release.Artist, out value))
+            {
+                value.ArtistName = item.Release.Artist;
+                value.ArtistUrl = $"https://www.discogs.com/artist/{item.Release.ArtistDiscogsId}";
+                value.UserReleasesInCollection = 1;
+                value.FirstAdded = item.DateAdded;
+                topArtists.Add(value.ArtistName, value);
+            }
+            else
+            {
+                value.UserReleasesInCollection += 1;
+                if (item.DateAdded < value.FirstAdded)
+                {
+                    value.FirstAdded = item.DateAdded;
+                }
+                topArtists[value.ArtistName] = value;
+            }
+        }
+        var artistPages = topArtists.Values.OrderByDescending(s => s.UserReleasesInCollection).ToList()
+            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+
+        var counter = 1;
+        var pageCounter = 1;
+
+        foreach (var artistPage in artistPages)
+        {
+            var artistPageString = new StringBuilder();
+            foreach (var artist in artistPage)
+            {
+                var name =
+                    $"**[{artist.ArtistName}]({artist.ArtistUrl})** ({artist.UserReleasesInCollection} {StringExtensions.GetReleasesString(artist.UserReleasesInCollection)})";
+
+                // TODO for those who know how to deal with this: honor Billboard :)
+                artistPageString.Append($"{counter}. ");
+                artistPageString.AppendLine(name);
+
+                counter++;
+            }
+            var footer = new StringBuilder();
+            footer.Append($"Page {pageCounter}/{artistPages.Count}");
+            footer.Append($" - {topArtists.Count} different artists added to collection in this time period");
+            pages.Add(new PageBuilder()
+                .WithDescription(artistPageString.ToString())
+                .WithAuthor(response.EmbedAuthor)
+                .WithFooter(footer.ToString()));
+            pageCounter++;
+
         }
 
         response.StaticPaginator = StringService.BuildStaticPaginator(pages);

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -291,26 +291,26 @@ public class DiscogsBuilder
             if (item.DateAdded < timeSettings.StartDateTime || item.DateAdded >= timeSettings.EndDateTime) {
                 continue;
             }
-            TopDiscogsArtist artist = null;
-            if (!topArtists.TryGetValue(item.Release.Artist, out artist))
-            {
-                artist = new TopDiscogsArtist{
-                    ArtistName=item.Release.Artist,
-                    ArtistUrl=$"https://www.discogs.com/artist/{item.Release.ArtistDiscogsId}",
-                    UserReleasesInCollection=1,
-                    FirstAdded=item.DateAdded
-                };
-            }
-            else
+
+            if (topArtists.TryGetValue(item.Release.Artist, out var artist))
             {
                 artist.UserReleasesInCollection += 1;
                 if (item.DateAdded < artist.FirstAdded)
                 {
                     artist.FirstAdded = item.DateAdded;
                 }
+                topArtists[artist.ArtistName] = artist;
             }
-            topArtists[artist.ArtistName] = artist;
+            else {
+                topArtists[item.Release.Artist] = new TopDiscogsArtist{
+                    ArtistName=item.Release.Artist,
+                    ArtistUrl=$"https://www.discogs.com/artist/{item.Release.ArtistDiscogsId}",
+                    UserReleasesInCollection=1,
+                    FirstAdded=item.DateAdded
+                };
+            }
         }
+
         var artistPages = topArtists.Values.OrderByDescending(s => s.UserReleasesInCollection).ToList()
             .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
 

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -88,7 +88,7 @@ public class DiscogsBuilder
         {
             await this._discogsService.StoreDiscogsAuth(context.ContextUser.UserId, user.Auth, user.Identity);
 
-            response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}]({Constants.DiscogsUserURL}{user.Identity.Username})' has been connected.\n" +
+            response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}]({Constants.DiscogsUserUrl}{user.Identity.Username})' has been connected.\n" +
                                         $"Run the `{context.Prefix}collection` command to view your collection.");
             response.CommandResponse = CommandResponse.Ok;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
@@ -156,7 +156,7 @@ public class DiscogsBuilder
             ? $"Discogs collection for {userTitle}"
             : $"Discogs collection for {userSettings.DisplayName}, requested by {userTitle}");
 
-        response.EmbedAuthor.WithUrl($"{Constants.DiscogsUserURL}{user.UserDiscogs.Username}/collection");
+        response.EmbedAuthor.WithUrl($"{Constants.DiscogsUserUrl}{user.UserDiscogs.Username}/collection");
         response.Embed.WithAuthor(response.EmbedAuthor);
 
         var pages = new List<PageBuilder>();
@@ -279,7 +279,7 @@ public class DiscogsBuilder
                 $"{user.UserDiscogs.Username}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
         }
         var userUrl =
-            $"{Constants.DiscogsUserURL}{user.UserDiscogs.Username}/collection";
+            $"{Constants.DiscogsUserUrl}{user.UserDiscogs.Username}/collection";
 
         response.EmbedAuthor.WithName($"Top {timeSettings.Description.ToLower()} Discogs artists for {userTitle}");
         response.EmbedAuthor.WithUrl(userUrl);
@@ -291,24 +291,25 @@ public class DiscogsBuilder
             if (item.DateAdded < timeSettings.StartDateTime || item.DateAdded >= timeSettings.EndDateTime) {
                 continue;
             }
-            TopDiscogsArtist value = null;
-            if (!topArtists.TryGetValue(item.Release.Artist, out value))
+            TopDiscogsArtist artist = null;
+            if (!topArtists.TryGetValue(item.Release.Artist, out artist))
             {
-                value.ArtistName = item.Release.Artist;
-                value.ArtistUrl = $"https://www.discogs.com/artist/{item.Release.ArtistDiscogsId}";
-                value.UserReleasesInCollection = 1;
-                value.FirstAdded = item.DateAdded;
-                topArtists.Add(value.ArtistName, value);
+                artist = new TopDiscogsArtist{
+                    ArtistName=item.Release.Artist,
+                    ArtistUrl=$"https://www.discogs.com/artist/{item.Release.ArtistDiscogsId}",
+                    UserReleasesInCollection=1,
+                    FirstAdded=item.DateAdded
+                };
             }
             else
             {
-                value.UserReleasesInCollection += 1;
-                if (item.DateAdded < value.FirstAdded)
+                artist.UserReleasesInCollection += 1;
+                if (item.DateAdded < artist.FirstAdded)
                 {
-                    value.FirstAdded = item.DateAdded;
+                    artist.FirstAdded = item.DateAdded;
                 }
-                topArtists[value.ArtistName] = value;
             }
+            topArtists[artist.ArtistName] = artist;
         }
         var artistPages = topArtists.Values.OrderByDescending(s => s.UserReleasesInCollection).ToList()
             .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);

--- a/src/FMBot.Bot/Extensions/StringExtensions.cs
+++ b/src/FMBot.Bot/Extensions/StringExtensions.cs
@@ -161,6 +161,11 @@ public static class StringExtensions
         return days == 1 ? "day" : "days";
     }
 
+    public static string GetReleasesString(long? releases)
+    {
+        return releases == 1 ? "release" : "releases";
+    }
+
     public static string GetChangeString(decimal oldValue, decimal newValue)
     {
         if (oldValue < newValue)

--- a/src/FMBot.Bot/Models/TopListModel.cs
+++ b/src/FMBot.Bot/Models/TopListModel.cs
@@ -6,14 +6,16 @@ public class TopListSettings
     {
     }
 
-    public TopListSettings(bool extraLarge, bool billboard)
+    public TopListSettings(bool extraLarge, bool billboard, bool discogs = false)
     {
         this.ExtraLarge = extraLarge;
         this.Billboard = billboard;
+        this.Discogs = discogs;
     }
 
     public bool ExtraLarge { get; set; }
 
     public bool Billboard { get; set; }
+    public bool Discogs { get; set; }
     public string NewSearchValue { get; set; }
 }

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -320,6 +320,7 @@ public class SettingService
         {
             Billboard = false,
             ExtraLarge = false,
+            Discogs = false,
             NewSearchValue = extraOptions
         };
 
@@ -340,6 +341,12 @@ public class SettingService
         {
             topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, extraLarge);
             topListSettings.ExtraLarge = true;
+        }
+        var discogs = new[] { "discogs" };
+        if (Contains(extraOptions, discogs))
+        {
+            topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, discogs);
+            topListSettings.Discogs = true;
         }
 
         return topListSettings;

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -342,7 +342,7 @@ public class SettingService
             topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, extraLarge);
             topListSettings.ExtraLarge = true;
         }
-        var discogs = new[] { "discogs" };
+        var discogs = new[] { "dc", "discogs" };
         if (Contains(extraOptions, discogs))
         {
             topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, discogs);

--- a/src/FMBot.Bot/Services/StringService.cs
+++ b/src/FMBot.Bot/Services/StringService.cs
@@ -7,6 +7,7 @@ using Fergun.Interactive;
 using Fergun.Interactive.Pagination;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Resources;
+using FMBot.Domain;
 using FMBot.Domain.Models;
 using FMBot.Persistence.Domain.Models;
 
@@ -229,7 +230,7 @@ public static class StringService
 
         description.Append($" - ");
 
-        description.Append($"[{discogsRelease.Release.Title}](https://www.discogs.com/release/{discogsRelease.Release.DiscogsId})");
+        description.Append($"[{discogsRelease.Release.Title}]({Constants.DiscordReleaseURL}/{discogsRelease.Release.DiscogsId})");
         description.Append("**");
 
         description.AppendLine();
@@ -264,7 +265,7 @@ public static class StringService
 
         description.Append(GetDiscogsFormatEmote(discogsRelease.Release.Format));
 
-        description.Append($" [{discogsRelease.Release.Format}](https://www.discogs.com/release/{discogsRelease.Release.DiscogsId})");
+        description.Append($" [{discogsRelease.Release.Format}]({Constants.DiscordReleaseURL}{discogsRelease.Release.DiscogsId})");
         if (discogsRelease.Release.FormatText != null)
         {
             description.Append($" - *{discogsRelease.Release.FormatText}*");
@@ -317,7 +318,7 @@ public static class StringService
         description.Append(formatEmote ?? discogsRelease.Release.Format);
 
         description.Append(
-            $" - **[{discogsRelease.Release.Title}](https://www.discogs.com/release/{discogsRelease.Release.DiscogsId})**");
+            $" - **[{discogsRelease.Release.Title}]({Constants.DiscordReleaseURL}{discogsRelease.Release.DiscogsId})**");
 
         if (discogsRelease.Release.FormatText != null)
         {

--- a/src/FMBot.Bot/Services/StringService.cs
+++ b/src/FMBot.Bot/Services/StringService.cs
@@ -230,7 +230,7 @@ public static class StringService
 
         description.Append($" - ");
 
-        description.Append($"[{discogsRelease.Release.Title}]({Constants.DiscordReleaseURL}/{discogsRelease.Release.DiscogsId})");
+        description.Append($"[{discogsRelease.Release.Title}]({Constants.DiscordReleaseUrl}/{discogsRelease.Release.DiscogsId})");
         description.Append("**");
 
         description.AppendLine();
@@ -265,7 +265,7 @@ public static class StringService
 
         description.Append(GetDiscogsFormatEmote(discogsRelease.Release.Format));
 
-        description.Append($" [{discogsRelease.Release.Format}]({Constants.DiscordReleaseURL}{discogsRelease.Release.DiscogsId})");
+        description.Append($" [{discogsRelease.Release.Format}]({Constants.DiscordReleaseUrl}{discogsRelease.Release.DiscogsId})");
         if (discogsRelease.Release.FormatText != null)
         {
             description.Append($" - *{discogsRelease.Release.FormatText}*");
@@ -318,7 +318,7 @@ public static class StringService
         description.Append(formatEmote ?? discogsRelease.Release.Format);
 
         description.Append(
-            $" - **[{discogsRelease.Release.Title}]({Constants.DiscordReleaseURL}{discogsRelease.Release.DiscogsId})**");
+            $" - **[{discogsRelease.Release.Title}]({Constants.DiscordReleaseUrl}{discogsRelease.Release.DiscogsId})**");
 
         if (discogsRelease.Release.FormatText != null)
         {

--- a/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
@@ -23,6 +23,7 @@ public class TopSlashCommands : InteractionModuleBase
     private readonly TrackBuilders _trackBuilders;
     private readonly GenreBuilders _genreBuilders;
     private readonly CountryBuilders _countryBuilders;
+    private readonly DiscogsBuilder _discogsBuilders;
 
     private InteractiveService Interactivity { get; }
 
@@ -33,7 +34,8 @@ public class TopSlashCommands : InteractionModuleBase
         AlbumBuilders albumBuilders,
         TrackBuilders trackBuilders,
         GenreBuilders genreBuilders,
-        CountryBuilders countryBuilders)
+        CountryBuilders countryBuilders,
+        DiscogsBuilder discogsBuilders)
     {
         this._userService = userService;
         this._artistBuilders = artistBuilders;
@@ -43,6 +45,7 @@ public class TopSlashCommands : InteractionModuleBase
         this._trackBuilders = trackBuilders;
         this._genreBuilders = genreBuilders;
         this._countryBuilders = countryBuilders;
+        this._discogsBuilders = discogsBuilders;
     }
 
     [SlashCommand("artists", "Shows your top artists")]
@@ -52,16 +55,21 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Billboard", "Show top artists billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
         [Summary("XXL", "Show extra top artists")] bool extraLarge = false,
-        [Summary("Private", "Only show response to you")] bool privateResponse = false)
+        [Summary("Private", "Only show response to you")] bool privateResponse = false,
+        [Summary("Discogs", "Show top artists in Discord collection")] bool discogs = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard);
+        var topListSettings = new TopListSettings(extraLarge, billboard, discogs);
 
-        var response = await this._artistBuilders.TopArtistsAsync(new ContextModel(this.Context, contextUser), topListSettings, timeSettings, userSettings);
+        var response = topListSettings.Discogs
+            ? await this._discogsBuilders.DiscogsTopArtistsAsync(new ContextModel(this.Context, contextUser),
+                topListSettings, timeSettings, userSettings)
+            : await this._artistBuilders.TopArtistsAsync(new ContextModel(this.Context, contextUser),
+                topListSettings, timeSettings, userSettings);
 
         await this.Context.SendResponse(this.Interactivity, response, privateResponse);
         this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
@@ -56,7 +56,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("User", "The user to show (defaults to self)")] string user = null,
         [Summary("XXL", "Show extra top artists")] bool extraLarge = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
-        [Summary("Discogs", "Show top artists in Discord collection")] bool discogs = false)
+        [Summary("Discogs", "Show top artists in Discogs collection")] bool discogs = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -3,9 +3,9 @@ namespace FMBot.Domain;
 public static class Constants
 {
 
-    public const string DiscogsUserURL = "https://www.discogs.com/user/";
+    public const string DiscogsUserUrl = "https://www.discogs.com/user/";
 
-    public const string DiscordReleaseURL = "https://www.discogs.com/release/";
+    public const string DiscordReleaseUrl = "https://www.discogs.com/release/";
 
     public const string LastFMUserUrl = "https://www.last.fm/user/";
 

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -3,6 +3,10 @@ namespace FMBot.Domain;
 public static class Constants
 {
 
+    public const string DiscogsUserURL = "https://www.discogs.com/user/";
+
+    public const string DiscordReleaseURL = "https://www.discogs.com/release/";
+
     public const string LastFMUserUrl = "https://www.last.fm/user/";
 
     public const string LastFmNonExistentImageName = "2a96cbd8b46e442fc41c2b86b821562f.png";

--- a/src/FMBot.Domain/Models/TopArtist.cs
+++ b/src/FMBot.Domain/Models/TopArtist.cs
@@ -29,3 +29,11 @@ public class TopArtist
 
     public List<string> Genres { get; set; }
 }
+
+public class TopDiscogsArtist
+{
+    public string ArtistName { get; set; }
+    public string ArtistUrl { get; set; }
+    public long? UserReleasesInCollection { get; set; }
+    public DateTime? FirstAdded { get; set; }
+}


### PR DESCRIPTION
this pr introduces `discogs` as a keyword in `.topartists`, which orders artists based on number of releases in the user's discogs collection. the text and slash commands go into a different branch when the flag is set, but the output _should_ look similar to the normal output.

`DiscogsTopArtistsAsync` is largely modeled after `TopArtistsAsync` in `src/FMBot.Bot/Builders/ArtistBuilders.cs`, though at the moment missing functionality to honor Billboard (hence the TODO). i feel like the right place for it is `src/FMBot.Bot/Builders/DiscogsBuilder.cs`, so that's where i put that function. time period should be honored if my assumptions about this stuff works is correct. :)

additionally, i've introduced a few discogs url constants to minimize magic strings here and there (i've got a magic string for artist url, but that's because it's the only occurrence of that url in the codebase at the moment).