### PR TITLE
shows title even though no users on the server knows the resource

### DIFF
--- a/src/FMBot.Bot/Builders/AlbumBuilders.cs
+++ b/src/FMBot.Bot/Builders/AlbumBuilders.cs
@@ -365,7 +365,7 @@ public class AlbumBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"in <b>{context.DiscordGuild.Name}</b>", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"in <b>{context.DiscordGuild.Name}</b>", albumCoverUrl, fullAlbumName,
                 filteredUsersWithAlbum, context.ContextUser.UserId, PrivacyLevel.Server);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -503,7 +503,7 @@ public class AlbumBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"from <b>{userTitle}</b>'s friends", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"from <b>{userTitle}</b>'s friends", albumCoverUrl, albumName,
                 usersWithAlbum, context.ContextUser.UserId, PrivacyLevel.Server);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -622,7 +622,7 @@ public class AlbumBuilders
 
         if (settings.WhoKnowsMode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"in <b>.fmbot 🌐</b>", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Album", $"in <b>.fmbot 🌐</b>", albumCoverUrl, albumName,
                 filteredUsersWithAlbum, context.ContextUser.UserId, privacyLevel, hidePrivateUsers: settings.HidePrivateUsers);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -774,7 +774,7 @@ public class ArtistBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"in <b>{context.DiscordGuild.Name}</b>", cachedArtist.SpotifyImageUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"in <b>{context.DiscordGuild.Name}</b>", cachedArtist.SpotifyImageUrl, artistSearch.Artist.ArtistName,
                 filteredUsersWithArtist, context.ContextUser.UserId, PrivacyLevel.Server, crownModel?.Crown, crownModel?.CrownHtmlResult);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -900,7 +900,7 @@ public class ArtistBuilders
 
         if (settings.WhoKnowsMode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"in <b>.fmbot 🌐</b>", cachedArtist?.SpotifyImageUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"in <b>.fmbot 🌐</b>", cachedArtist?.SpotifyImageUrl, artistSearch.Artist.ArtistName,
                 filteredUsersWithArtist, context.ContextUser.UserId, privacyLevel, hidePrivateUsers: settings.HidePrivateUsers);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -1023,7 +1023,7 @@ public class ArtistBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"from <b>{userTitle}</b>'s friends", cachedArtist.SpotifyImageUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows", $"from <b>{userTitle}</b>'s friends", cachedArtist.SpotifyImageUrl, artistSearch.Artist.ArtistName,
                 usersWithArtist, context.ContextUser.UserId, PrivacyLevel.Server);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);

--- a/src/FMBot.Bot/Builders/TrackBuilders.cs
+++ b/src/FMBot.Bot/Builders/TrackBuilders.cs
@@ -265,7 +265,7 @@ public class TrackBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"in <b>{context.DiscordGuild.Name}</b>", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"in <b>{context.DiscordGuild.Name}</b>", albumCoverUrl, trackName,
                 filteredUsersWithTrack, context.ContextUser.UserId, PrivacyLevel.Server);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -373,7 +373,7 @@ public class TrackBuilders
 
         if (mode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"from <b>{userTitle}</b>'s friends", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"from <b>{userTitle}</b>'s friends", albumCoverUrl, trackName,
                 usersWithTrack, context.ContextUser.UserId, PrivacyLevel.Server);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);
@@ -479,7 +479,7 @@ public class TrackBuilders
 
         if (settings.WhoKnowsMode == WhoKnowsMode.Image)
         {
-            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"in <b>.fmbot 🌐</b>", albumCoverUrl,
+            var image = await this._puppeteerService.GetWhoKnows("WhoKnows Track", $"in <b>.fmbot 🌐</b>", albumCoverUrl, trackName,
                 filteredUsersWithTrack, context.ContextUser.UserId, privacyLevel, hidePrivateUsers: settings.HidePrivateUsers);
 
             var encoded = image.Encode(SKEncodedImageFormat.Png, 100);

--- a/src/FMBot.Images/Generators/PuppeteerService.cs
+++ b/src/FMBot.Images/Generators/PuppeteerService.cs
@@ -78,14 +78,13 @@ public class PuppeteerService
         return skImg;
     }
 
-    public async Task<SKBitmap> GetWhoKnows(string type, string location, string imageUrl, IList<WhoKnowsObjectWithUser> whoKnowsObjects, int requestedUserId,
+    public async Task<SKBitmap> GetWhoKnows(string type, string location, string imageUrl, string title, IList<WhoKnowsObjectWithUser> whoKnowsObjects, int requestedUserId,
         PrivacyLevel minPrivacyLevel, UserCrown userCrown = null, string crownText = null, bool hidePrivateUsers = false)
     {
         await this._initializationTask;
 
         await using var page = await this._browser.NewPageAsync();
 
-        var title = whoKnowsObjects.FirstOrDefault()?.Name ?? "Unknown";
         var extraHeight = 0;
         if (title.Length > 38)
         {


### PR DESCRIPTION
This fixes an edge case in various `whoknows`-commands: If a user requests `whoknows`, with `WhoKnowsMode.Image`, on an artist, album or track that no one on the server has listened to, the title will be set to "Unknown". This is because the title has been dependent on a single user knowing the resource.
This becomes a discrepancy with the embed version, where the title gets set correctly regardless.

As such, I've expanded `GetWhoKnows` in src/FMBot.Images/Generators/PuppeteerService.cs to receive title from the caller instead of trying to decide on its own.