### PR TITLE
wip: query formats in discogs/collection

### DIFF
--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -152,7 +152,7 @@ public class DiscogsBuilder
 
         if (collectionSettings.Formats.Count > 0)
         {
-            releases = releases.Where(w => collectionSettings.Formats.Contains(DiscogsCollectionSettings.ToDiscogsFormat(w.Release.Format))).ToList();
+            releases = releases.Where(w => collectionSettings.Formats.Contains(DiscogsCollectionSettings.ToDiscogsFormat(w.Release.Format).format)).ToList();
         }
 
         var userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -152,7 +152,6 @@ public class DiscogsBuilder
 
         if (collectionSettings.Formats.Count > 0)
         {
-            
             releases = releases.Where(w => collectionSettings.Formats.Contains(DiscogsCollectionSettings.ToDiscogsFormat(w.Release.Format))).ToList();
         }
 

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -106,6 +106,7 @@ public class DiscogsBuilder
 
     public async Task<ResponseModel> DiscogsCollectionAsync(ContextModel context,
         UserSettingsModel userSettings,
+        DiscogsCollectionSettings collectionSettings,
         string searchValues)
     {
         var response = new ResponseModel
@@ -147,6 +148,12 @@ public class DiscogsBuilder
 
             releases = releases.Where(w => w.Release.Title.ToLower().Contains(searchValues) ||
                                            w.Release.Artist.ToLower().Contains(searchValues)).ToList();
+        }
+
+        if (collectionSettings.Formats.Count > 0)
+        {
+            
+            releases = releases.Where(w => collectionSettings.Formats.Contains(DiscogsCollectionSettings.ToDiscogsFormat(w.Release.Format))).ToList();
         }
 
         var userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);

--- a/src/FMBot.Bot/Models/DiscogsModels.cs
+++ b/src/FMBot.Bot/Models/DiscogsModels.cs
@@ -11,22 +11,24 @@ public class DiscogsCollectionSettings
 
     public DiscogsCollectionSettings(List<string> formats)
     {
-        this.Formats = formats.ConvertAll(format => ToDiscogsFormat(format));
+        this.Formats = formats.ConvertAll(format => ToDiscogsFormat(format).format);
     }
 
     public List<DiscogsFormat> Formats { get; set; }
     public string NewSearchValue { get; set; }
 
-    public static DiscogsFormat ToDiscogsFormat(string format) {
+    public static (DiscogsFormat format, string value) ToDiscogsFormat(string format) {
+        format = format.ToLower();
+
         switch (format) {
             case "vinyl" or "vinyls" or "records":
-                return DiscogsFormat.Vinyl;
+                return (DiscogsFormat.Vinyl, format);
             case "tape" or "tapes" or "cassette" or "cassettes":
-                return DiscogsFormat.Cassette;
-            case "cd" or "CD" or "cds" or "CDs":
-                return DiscogsFormat.Cd;
+                return (DiscogsFormat.Cassette, format);
+            case "cd" or "cds":
+                return (DiscogsFormat.Cd, format);
             default:
-                return DiscogsFormat.Miscellaneous;
+                return (DiscogsFormat.Miscellaneous, null);
         }
     }
 }

--- a/src/FMBot.Bot/Models/DiscogsModels.cs
+++ b/src/FMBot.Bot/Models/DiscogsModels.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FMBot.Bot.Models;
+
+
+public enum DiscogsFormat {
+    Vinyl,
+    Cassette,
+    Cd,
+    Miscellaneous,
+    Unknown,
+}
+
+public class DiscogsCollectionSettings
+{
+    public DiscogsCollectionSettings()
+    {
+    }
+
+    public DiscogsCollectionSettings(List<string> formats)
+    {
+        this.Formats = formats.ConvertAll(format => ToDiscogsFormat(format));
+    }
+
+    public List<DiscogsFormat> Formats { get; set; }
+    public string NewSearchValue { get; set; }
+
+    public static DiscogsFormat ToDiscogsFormat(string format) {
+        switch (format) {
+            case "vinyl" or "vinyls" or "records":
+                return DiscogsFormat.Vinyl;
+            case "tape" or "tapes" or "cassette" or "cassettes":
+                return DiscogsFormat.Cassette;
+            case "cd" or "CD" or "cds" or "CDs":
+                return DiscogsFormat.Cd;
+            case "misc" or "miscellaneous":
+                return DiscogsFormat.Miscellaneous;
+            default:
+                return DiscogsFormat.Unknown;
+        }
+    }
+}

--- a/src/FMBot.Bot/Models/DiscogsModels.cs
+++ b/src/FMBot.Bot/Models/DiscogsModels.cs
@@ -3,15 +3,6 @@ using System.Linq;
 
 namespace FMBot.Bot.Models;
 
-
-public enum DiscogsFormat {
-    Vinyl,
-    Cassette,
-    Cd,
-    Miscellaneous,
-    Unknown,
-}
-
 public class DiscogsCollectionSettings
 {
     public DiscogsCollectionSettings()
@@ -34,10 +25,8 @@ public class DiscogsCollectionSettings
                 return DiscogsFormat.Cassette;
             case "cd" or "CD" or "cds" or "CDs":
                 return DiscogsFormat.Cd;
-            case "misc" or "miscellaneous":
-                return DiscogsFormat.Miscellaneous;
             default:
-                return DiscogsFormat.Unknown;
+                return DiscogsFormat.Miscellaneous;
         }
     }
 }

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -337,25 +337,32 @@ public class SettingService
             return collectionSettings;
         }
 
-        var vinylFormats = new[] { "format:vinyl", "f:vinyl" };
+        var vinylFormats = new[] { "vinyl", "vinyls", "records" };
         if (Contains(extraOptions, vinylFormats))
         {
             collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, vinylFormats);
             collectionSettings.Formats.Add(DiscogsFormat.Vinyl);
         }
 
-        var tapeFormats = new[] { "format:cassette", "format:cassettes", "f:cassette", "f:cassettes", "format:tape", "f:tape", "format:tapes", "f:tapes" };
+        var tapeFormats = new[] { "cassette", "cassettes", "tape", "tapes" };
         if (Contains(extraOptions, tapeFormats))
         {
             collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, tapeFormats);
             collectionSettings.Formats.Add(DiscogsFormat.Cassette);
         }
 
-        var cdFormats = new[] { "format:cd", "format:CD", "f:cd", "f:CD" };
+        var cdFormats = new[] { "cd", "CD", "cds", "CDs" };
         if (Contains(extraOptions, cdFormats))
         {
             collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, cdFormats);
             collectionSettings.Formats.Add(DiscogsFormat.Cd);
+        }
+
+        var miscFormats = new[] { "misc", "miscellaneous" };
+        if (Contains(extraOptions, miscFormats))
+        {
+            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, miscFormats);
+            collectionSettings.Formats.Add(DiscogsFormat.Miscellaneous);
         }
 
         return collectionSettings;

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -324,6 +324,43 @@ public class SettingService
         return settingsModel;
     }
 
+    public static DiscogsCollectionSettings SetDiscogsCollectionSettings(string extraOptions = null)
+    {
+        var collectionSettings = new DiscogsCollectionSettings
+        {
+            Formats = new List<DiscogsFormat>(),
+            NewSearchValue = extraOptions
+        };
+        
+        if (extraOptions == null)
+        {
+            return collectionSettings;
+        }
+
+        var vinylFormats = new[] { "format:vinyl", "f:vinyl" };
+        if (Contains(extraOptions, vinylFormats))
+        {
+            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, vinylFormats);
+            collectionSettings.Formats.Add(DiscogsFormat.Vinyl);
+        }
+
+        var tapeFormats = new[] { "format:cassette", "format:cassettes", "f:cassette", "f:cassettes", "format:tape", "f:tape", "format:tapes", "f:tapes" };
+        if (Contains(extraOptions, tapeFormats))
+        {
+            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, tapeFormats);
+            collectionSettings.Formats.Add(DiscogsFormat.Cassette);
+        }
+
+        var cdFormats = new[] { "format:cd", "format:CD", "f:cd", "f:CD" };
+        if (Contains(extraOptions, cdFormats))
+        {
+            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, cdFormats);
+            collectionSettings.Formats.Add(DiscogsFormat.Cd);
+        }
+
+        return collectionSettings;
+    }
+
     public static TopListSettings SetTopListSettings(string extraOptions = null)
     {
         var topListSettings = new TopListSettings

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -337,25 +337,16 @@ public class SettingService
             return collectionSettings;
         }
 
-        var vinylFormats = new[] { "vinyl", "vinyls", "records" };
-        if (Contains(extraOptions, vinylFormats))
-        {
-            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, vinylFormats);
-            collectionSettings.Formats.Add(DiscogsFormat.Vinyl);
-        }
+        var searchTerms = collectionSettings.NewSearchValue.Split(' ');
 
-        var tapeFormats = new[] { "cassette", "cassettes", "tape", "tapes" };
-        if (Contains(extraOptions, tapeFormats))
+        foreach (var word in searchTerms)
         {
-            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, tapeFormats);
-            collectionSettings.Formats.Add(DiscogsFormat.Cassette);
-        }
-
-        var cdFormats = new[] { "cd", "CD", "cds", "CDs" };
-        if (Contains(extraOptions, cdFormats))
-        {
-            collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, cdFormats);
-            collectionSettings.Formats.Add(DiscogsFormat.Cd);
+            var discogsFormat = DiscogsCollectionSettings.ToDiscogsFormat(word);
+            if (discogsFormat.value != null)
+            {
+                collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, new[] { word });
+                collectionSettings.Formats.Add(discogsFormat.format);
+            }
         }
 
         var miscFormats = new[] { "misc", "miscellaneous" };
@@ -364,6 +355,8 @@ public class SettingService
             collectionSettings.NewSearchValue = ContainsAndRemove(collectionSettings.NewSearchValue, miscFormats);
             collectionSettings.Formats.Add(DiscogsFormat.Miscellaneous);
         }
+
+        collectionSettings.Formats = collectionSettings.Formats.Distinct().ToList();
 
         return collectionSettings;
     }

--- a/src/FMBot.Bot/SlashCommands/DiscogsSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/DiscogsSlashCommands.cs
@@ -63,13 +63,16 @@ public class DiscogsSlashCommands : InteractionModuleBase
     public async Task AlbumAsync(
         [Summary("Search", "Search query to filter on")] string search = null,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("Formats", "Formats to include")] params string[] formats)
+        [Summary("Format", "Media format to include")] DiscogsFormat? format = null)
     {
         _ = DeferAsync();
 
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
-        var collectionSettings = new DiscogsCollectionSettings(new List<string>(formats));
+        var collectionSettings = new DiscogsCollectionSettings
+        {
+            Formats = format != null ? new List<DiscogsFormat>{(DiscogsFormat)format} : new()
+        };
 
         try
         {

--- a/src/FMBot.Bot/SlashCommands/DiscogsSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/DiscogsSlashCommands.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Interactions;
@@ -61,16 +62,18 @@ public class DiscogsSlashCommands : InteractionModuleBase
     [UsernameSetRequired]
     public async Task AlbumAsync(
         [Summary("Search", "Search query to filter on")] string search = null,
-        [Summary("User", "The user to show (defaults to self)")] string user = null)
+        [Summary("User", "The user to show (defaults to self)")] string user = null,
+        [Summary("Formats", "Formats to include")] params string[] formats)
     {
         _ = DeferAsync();
 
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
+        var collectionSettings = new DiscogsCollectionSettings(new List<string>(formats));
 
         try
         {
-            var response = await this._discogsBuilder.DiscogsCollectionAsync(new ContextModel(this.Context, contextUser), userSettings, search);
+            var response = await this._discogsBuilder.DiscogsCollectionAsync(new ContextModel(this.Context, contextUser), userSettings, collectionSettings, search);
 
             await this.Context.SendFollowUpResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Bot/TextCommands/DiscogsCommands.cs
+++ b/src/FMBot.Bot/TextCommands/DiscogsCommands.cs
@@ -78,11 +78,12 @@ public class DiscogsCommands : BaseCommandModule
 
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(searchValues, contextUser, this.Context);
+        var collectionSettings = SettingService.SetDiscogsCollectionSettings(userSettings.NewSearchValue);
         var prfx = this._prefixService.GetPrefix(this.Context.Guild?.Id);
 
         try
         {
-            var response = await this._discogsBuilder.DiscogsCollectionAsync(new ContextModel(this.Context, prfx, contextUser), userSettings, userSettings.NewSearchValue);
+            var response = await this._discogsBuilder.DiscogsCollectionAsync(new ContextModel(this.Context, prfx, contextUser), userSettings, collectionSettings, collectionSettings.NewSearchValue);
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Domain/Enums/DiscogsFormat.cs
+++ b/src/FMBot.Domain/Enums/DiscogsFormat.cs
@@ -1,0 +1,6 @@
+public enum DiscogsFormat {
+    Vinyl,
+    Cassette,
+    Cd,
+    Miscellaneous,
+}


### PR DESCRIPTION
enables format querying in `.collection`, i.e. `.collection format:vinyl`.

i certainly don't enjoy how the function in `src/FMBot.Bot/Services/SettingService.cs` has turned out. 
ideally, i'd have a function that finds `(f|format):(\w+)` and then spits out a `DiscogsFormat` for the second capture group.
`DiscogsModels.ToDiscogsFormat()` is halfway there, but even that function's kind of dumb. :(

i'd appreciate if you looked over this and gave some initial thoughts, and meanwhile i'll think more about how to implement what i want lol
