### PR TITLE
Support Jockie music scrobbling (pt. 2)

### DIFF
--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -130,7 +130,9 @@ public class UserBuilder
                                     "Currently supported bots:\n" +
                                     "- Hydra (Only with Now Playing messages enabled in English)\n" +
                                     "- Cakey Bot (Only with Now Playing messages enabled in English)\n" +
-                                    "- SoundCloud");
+                                    "- Jockie Music (Only with Started Playing messages enabled in English)\n" +
+                                    "- SoundCloud"
+                                    );
 
         if ((newBotScrobblingDisabledSetting == null || newBotScrobblingDisabledSetting == false) && !string.IsNullOrWhiteSpace(context.ContextUser.SessionKeyLastFm))
         {

--- a/src/FMBot.Tests/JockieMusicBotTest.cs
+++ b/src/FMBot.Tests/JockieMusicBotTest.cs
@@ -36,4 +36,16 @@ public class JockieMusicBotTest
         Assert.That(Jockie.ShouldIgnoreMessage(this._mockedMessage.Object), Is.False);
     }
 
+    [Test]
+    [TestCase(" ​ Started playing **[Constant Headache by Joyce Manor](https://www.deezer.com/track/67220083)**")]
+    [TestCase("<:deezer:837244412492513312> ​ Started playing **[UWU by KEAN DYSSO](https://www.deezer.com/track/1659395942)**")]
+    [TestCase("<:apple_music:837244414531076106> ​ Started playing **[River by Anonymouz](https://music.apple.com/us/album/river/1658961980?i=1658961985)**")]
+    [TestCase("<:apple_music:837244414531076106> ​ Started playing **[Modern Love by All Time Low](https://music.apple.com/us/album/modern-love/1664275076?i=1664275308)**")]
+    public void TestGetTrackQuery(string description)
+    {
+        this._mockedEmbed.Setup(m => m.Description).Returns(description);
+        var expected = description[description.IndexOf(" ​ Started playing ", StringComparison.Ordinal)..];
+        Assert.That(expected, Is.EqualTo(Jockie.GetTrackQuery(this._mockedMessage.Object)));
+    }
+
 }

--- a/src/FMBot.Tests/TrackServiceTest.cs
+++ b/src/FMBot.Tests/TrackServiceTest.cs
@@ -1,0 +1,27 @@
+﻿using FMBot.Bot.Services;
+
+namespace FMBot.Tests;
+
+public class TrackServiceTest
+{
+
+    [Test]
+    [TestCase("**bye** **by** **bye**", "bye", "bye")]
+    [TestCase("**bye** **by** **by bye**", "bye", "by bye")]
+    [TestCase("**bye by** **by** **bye**", "bye by", "bye")]
+    [TestCase("**bye by** **by** **by bye**", "bye by", "by bye")]
+    [TestCase("**All by Yourself** **by** **Panic! At the Disco**", "All by Yourself", "Panic! At the Disco")]
+    [TestCase("**The Black Parade** **by** **My Chemical Romance**", "The Black Parade", "My Chemical Romance")]
+    [TestCase("**The Black Parade** *by** **My Chemical Romance**", null, null)]
+    [TestCase("*The Black Parade** **by** **My Chemical Romance**", null, null)]
+    [TestCase("The Black Parade **by** My Chemical Romance", null, null)]
+    [TestCase("**The Black Parade by My Chemical Romance**", null, null)]
+    public void TestParseBoldDelimitedTrackAndArtist(string description, string? track, string? artist)
+    {
+        var expectedTrackAndArtist = track != null && artist != null
+            ? new TrackService.TrackAndArtist() { Track = track, Artist = artist }
+            : null;
+        var trackAndArtist = TrackService.ParseBoldDelimitedTrackAndArtist(description);
+        Assert.That(trackAndArtist, Is.EqualTo(expectedTrackAndArtist));
+    }
+}


### PR DESCRIPTION
Had a conversation with the Jockie Bot developer and we came to an agreement for how to best handle track parsing detailed in #219: Track and Artist information will be separated by bold formatting going forward, ex.

`[**Track** **by** **Artist**]`

I've been told the formatting change has reached 75% of servers using Jockie as of earlier this week. This PR supports the new format.