### PR TITLE
Move jobs to hangfire

### DIFF
--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -79,7 +79,7 @@ public class UserBuilder
 
         var guildUsers = await this._guildService.GetGuildUsers(context.DiscordGuild?.Id);
 
-        if (this._timer._currentFeatured == null)
+        if (this._timer.CurrentFeatured == null)
         {
             response.ResponseType = ResponseType.Text;
             response.Text = ".fmbot is still starting up, please try again in a bit..";
@@ -87,18 +87,18 @@ public class UserBuilder
             return response;
         }
 
-        response.Embed.WithThumbnailUrl(this._timer._currentFeatured.ImageUrl);
-        response.Embed.AddField("Featured:", this._timer._currentFeatured.Description);
+        response.Embed.WithThumbnailUrl(this._timer.CurrentFeatured.ImageUrl);
+        response.Embed.AddField("Featured:", this._timer.CurrentFeatured.Description);
 
-        if (context.DiscordGuild != null && guildUsers.Any() && this._timer._currentFeatured.UserId.HasValue && this._timer._currentFeatured.UserId.Value != 0)
+        if (context.DiscordGuild != null && guildUsers.Any() && this._timer.CurrentFeatured.UserId.HasValue && this._timer.CurrentFeatured.UserId.Value != 0)
         {
-            guildUsers.TryGetValue(this._timer._currentFeatured.UserId.Value, out var guildUser);
+            guildUsers.TryGetValue(this._timer.CurrentFeatured.UserId.Value, out var guildUser);
 
             if (guildUser != null)
             {
                 response.Text = "in-server";
 
-                var dateValue = ((DateTimeOffset)this._timer._currentFeatured.DateTime.AddHours(1)).ToUnixTimeSeconds();
+                var dateValue = ((DateTimeOffset)this._timer.CurrentFeatured.DateTime.AddHours(1)).ToUnixTimeSeconds();
 
                 response.Embed.AddField("🥳 Congratulations!",
                     guildUser.DiscordUserId == context.DiscordUser.Id
@@ -107,7 +107,7 @@ public class UserBuilder
             }
         }
 
-        if (this._timer._currentFeatured.SupporterDay && context.ContextUser.UserType == UserType.User)
+        if (this._timer.CurrentFeatured.SupporterDay && context.ContextUser.UserType == UserType.User)
         {
             response.Components = new ComponentBuilder().WithButton(Constants.GetSupporterButton, style: ButtonStyle.Link, url: Constants.GetSupporterOverviewLink);
         }

--- a/src/FMBot.Bot/FMBot.Bot.csproj
+++ b/src/FMBot.Bot/FMBot.Bot.csproj
@@ -32,6 +32,9 @@
     <PackageReference Include="Genius.NET" Version="4.0.1" />
     <PackageReference Include="Google.Apis" Version="1.60.0" />
     <PackageReference Include="Google.Apis.YouTube.v3" Version="1.60.0.2945" />
+    <PackageReference Include="Hangfire" Version="1.8.2" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.2" />
+    <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="MetaBrainz.MusicBrainz" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.5" />

--- a/src/FMBot.Bot/HangfireActivator.cs
+++ b/src/FMBot.Bot/HangfireActivator.cs
@@ -1,0 +1,19 @@
+using System;
+using Hangfire;
+
+namespace FMBot.Bot;
+
+public class HangfireActivator : JobActivator
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public HangfireActivator(IServiceProvider serviceProvider)
+    {
+        this._serviceProvider = serviceProvider;
+    }
+
+    public override object ActivateJob(Type type)
+    {
+        return this._serviceProvider.GetService(type);
+    }
+}

--- a/src/FMBot.Bot/Services/AlbumService.cs
+++ b/src/FMBot.Bot/Services/AlbumService.cs
@@ -69,7 +69,7 @@ public class AlbumService
 
             if (searchValue.ToLower() == "featured")
             {
-                searchValue = $"{this._timer._currentFeatured.ArtistName} | {this._timer._currentFeatured.AlbumName}";
+                searchValue = $"{this._timer.CurrentFeatured.ArtistName} | {this._timer.CurrentFeatured.AlbumName}";
             }
 
             int? rndPosition = null;

--- a/src/FMBot.Bot/Services/ArtistsService.cs
+++ b/src/FMBot.Bot/Services/ArtistsService.cs
@@ -67,7 +67,7 @@ public class ArtistsService
 
             if (artistValues.ToLower() == "featured")
             {
-                artistValues = this._timer._currentFeatured.ArtistName;
+                artistValues = this._timer.CurrentFeatured.ArtistName;
             }
 
             int? rndPosition = null;

--- a/src/FMBot.Bot/Services/FeaturedService.cs
+++ b/src/FMBot.Bot/Services/FeaturedService.cs
@@ -41,7 +41,7 @@ public class FeaturedService
         this._cache = cache;
     }
 
-    public async Task<FeaturedLog> NewFeatured(ulong botUserId, DateTime? dateTime = null)
+    public async Task<FeaturedLog> NewFeatured(DateTime? dateTime = null)
     {
         var randomAvatarMode = RandomNumberGenerator.GetInt32(1, 4);
 
@@ -73,7 +73,7 @@ public class FeaturedService
         var featuredLog = new FeaturedLog
         {
             FeaturedMode = featuredMode,
-            BotType = BotTypeExtension.GetBotType(botUserId),
+            BotType = BotType.Production,
             DateTime = DateTime.SpecifyKind(dateTime ?? DateTime.UtcNow, DateTimeKind.Utc),
             HasFeatured = false,
             SupporterDay = supporterDay
@@ -563,7 +563,7 @@ public class FeaturedService
     {
         await using var db = await this._contextFactory.CreateDbContextAsync();
 
-        var newFeatured = await NewFeatured(botUserId, featuredLog.DateTime);
+        var newFeatured = await NewFeatured(featuredLog.DateTime);
 
         featuredLog.HasFeatured = false;
         featuredLog.AlbumName = newFeatured.AlbumName;

--- a/src/FMBot.Bot/Services/TrackService.cs
+++ b/src/FMBot.Bot/Services/TrackService.cs
@@ -83,10 +83,10 @@ public class TrackService
         {
             searchValue = trackValues;
 
-            if (searchValue.ToLower() == "featured" && this._timer._currentFeatured.TrackName != null)
+            if (searchValue.ToLower() == "featured" && this._timer.CurrentFeatured.TrackName != null)
             {
                 searchValue =
-                    $"{this._timer._currentFeatured.ArtistName} | {this._timer._currentFeatured.TrackName}";
+                    $"{this._timer.CurrentFeatured.ArtistName} | {this._timer.CurrentFeatured.TrackName}";
             }
 
             if (searchValue.Contains(" | "))

--- a/src/FMBot.Bot/Startup.cs
+++ b/src/FMBot.Bot/Startup.cs
@@ -31,8 +31,9 @@ using Microsoft.Extensions.DependencyInjection;
 using Serilog;
 using Serilog.Events;
 using Serilog.Exceptions;
-using Serilog.Sinks.Discord;
 using RunMode = Discord.Commands.RunMode;
+using Hangfire;
+using Hangfire.MemoryStorage;
 
 namespace FMBot.Bot;
 
@@ -94,6 +95,9 @@ public class Startup
         provider.GetRequiredService<UserEventHandler>();
 
         await provider.GetRequiredService<StartupService>().StartAsync(); // Start the startup service
+
+        // Start hangfire
+        using var server = new BackgroundJobServer();
 
         await Task.Delay(-1); // Keep the program alive
     }
@@ -213,6 +217,11 @@ public class Startup
             b.UseNpgsql(this.Configuration["Database:ConnectionString"]));
 
         services.AddMemoryCache();
+
+        services.AddHangfire(config =>
+        {
+            config.UseMemoryStorage();
+        });
     }
 
     private static void AppUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
@@ -441,7 +441,7 @@ public class AlbumCommands : BaseCommandModule
             searchValue = albumValues;
             if (searchValue.ToLower() == "featured")
             {
-                searchValue = $"{this._timer._currentFeatured.ArtistName} | {this._timer._currentFeatured.AlbumName}";
+                searchValue = $"{this._timer.CurrentFeatured.ArtistName} | {this._timer.CurrentFeatured.AlbumName}";
             }
             if (searchValue.Contains(" | "))
             {

--- a/src/FMBot.Discord.sln.DotSettings
+++ b/src/FMBot.Discord.sln.DotSettings
@@ -11,7 +11,9 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Danceability/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Discogs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=emoji/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Featureds/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=fmbot/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Instrumentalness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Jockie/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Lastfm/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
This moves all recurring jobs from Timers to proper recurring jobs inside of Hangfire.

Because persistence doesn't really matter for these jobs we will just use the memory storage option for Hangfire.