### PR TITLE
let different user be queried in .genre

### DIFF
--- a/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
@@ -12,7 +12,6 @@ using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.Guild;
-using FMBot.Domain.Models;
 
 
 namespace FMBot.Bot.SlashCommands;

--- a/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
@@ -12,6 +12,8 @@ using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.Guild;
+using FMBot.Domain.Models;
+
 
 namespace FMBot.Bot.SlashCommands;
 
@@ -20,15 +22,17 @@ public class GenreSlashCommands : InteractionModuleBase
     private readonly UserService _userService;
     private readonly GuildService _guildService;
     private readonly GenreBuilders _genreBuilders;
+    private readonly SettingService _settingService;
 
     private InteractiveService Interactivity { get; }
 
-    public GenreSlashCommands(UserService userService, InteractiveService interactivity, GenreBuilders genreBuilders, GuildService guildService)
+    public GenreSlashCommands(UserService userService, InteractiveService interactivity, GenreBuilders genreBuilders, GuildService guildService, SettingService settingService)
     {
         this._userService = userService;
         this.Interactivity = interactivity;
         this._genreBuilders = genreBuilders;
         this._guildService = guildService;
+        this._settingService = settingService;
     }
 
     [SlashCommand("genre", "Shows genre info for artist or top artists for genre")]
@@ -36,16 +40,18 @@ public class GenreSlashCommands : InteractionModuleBase
     public async Task GenreAsync(
         [Summary("search", "The genre or artist you want to view")]
         [Autocomplete(typeof(GenreArtistAutoComplete))]
-        string name = null)
+        string search = null,
+        [Summary("User", "The user to show (defaults to self)")] string user = null)
     {
         _ = DeferAsync();
 
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var guild = await this._guildService.GetGuildAsync(this.Context.Guild.Id);
+        var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         try
         {
-            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, contextUser), name, guild);
+            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, contextUser), search, userSettings, guild);
 
             await this.Context.SendFollowUpResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
@@ -74,10 +80,11 @@ public class GenreSlashCommands : InteractionModuleBase
 
         var contextUser = await this._userService.GetUserAsync(ulong.Parse(discordUserId));
         var guild = await this._guildService.GetGuildAsync(this.Context.Guild.Id);
+        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User, true);
 
         try
         {
-            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, contextUser), genre, guild, false);
+            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, contextUser), genre, userSettings, guild, false);
 
             await this.Context.UpdateInteractionEmbed(response, this.Interactivity);
             this.Context.LogCommandUsed(response.CommandResponse);
@@ -106,6 +113,7 @@ public class GenreSlashCommands : InteractionModuleBase
 
         var contextUser = await this._userService.GetUserAsync(ulong.Parse(discordUserId));
         var guild = await this._guildService.GetGuildAsync(this.Context.Guild.Id);
+        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User, true);
 
         try
         {
@@ -114,7 +122,7 @@ public class GenreSlashCommands : InteractionModuleBase
                 DiscordUser = await this.Context.Guild.GetUserAsync(ulong.Parse(discordUserId))
             };
 
-            var response = await this._genreBuilders.GenreAsync(context, genre, guild);
+            var response = await this._genreBuilders.GenreAsync(context, genre, userSettings, guild);
 
             await this.Context.UpdateInteractionEmbed(response, this.Interactivity);
             this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/GenreSlashCommands.cs
@@ -79,7 +79,7 @@ public class GenreSlashCommands : InteractionModuleBase
 
         var contextUser = await this._userService.GetUserAsync(ulong.Parse(discordUserId));
         var guild = await this._guildService.GetGuildAsync(this.Context.Guild.Id);
-        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User, true);
+        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User);
 
         try
         {
@@ -112,7 +112,7 @@ public class GenreSlashCommands : InteractionModuleBase
 
         var contextUser = await this._userService.GetUserAsync(ulong.Parse(discordUserId));
         var guild = await this._guildService.GetGuildAsync(this.Context.Guild.Id);
-        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User, true);
+        var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User);
 
         try
         {

--- a/src/FMBot.Bot/TextCommands/LastFM/GenreCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/GenreCommands.cs
@@ -116,7 +116,8 @@ public class GenreCommands : BaseCommandModule
 
         try
         {
-            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, prfx, contextUser), userView.NewSearchValue, guild, userView.User);
+            var userSettings = await this._settingService.GetUser(userView.NewSearchValue, contextUser, this.Context);
+            var response = await this._genreBuilders.GenreAsync(new ContextModel(this.Context, prfx, contextUser), userSettings.NewSearchValue, userSettings, guild, userView.User);
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);


### PR DESCRIPTION
it's been a long while since i've looked at this codebase, so apologies if my code is dumb.

the motivation for this change is as follows:
> imagine you're listening to something nice and you figure out that spotify classifies it as "future garage", and you'd like to get recommendations in that genre from someone you respect. you run `.g future garage @cool-person` and you'll get a good indication of what they would recommend without directly asking them

a few things that has confused me during development:

1. i'm not sure how to best get a `UserSettingsModel` where i think i'm supposed to get the calling user's model. i've just done it this way: `var userSettings = await this._settingService.GetUser(null, contextUser, this.Context.Guild, this.Context.User)` 
2. i'm not sure how `UserGenresAsync` and `GuildGenresAsync` in `GenreSlashCommands` are called. i'm especially unsure about the `UserGenresAsync` function as it kind of implies that another user could be queried here, but that's not how i've implemented it.

regardless, i believe the base cases of `/genre` and `.g` are covered, the two functions in point 2 above are still confusing to me and might require some more work.