### PR TITLE
8-track cartridge as a discogs format

### DIFF
--- a/src/FMBot.Bot/Models/DiscogsModels.cs
+++ b/src/FMBot.Bot/Models/DiscogsModels.cs
@@ -27,6 +27,8 @@ public class DiscogsCollectionSettings
                 return (DiscogsFormat.Cassette, format);
             case "cd" or "cds":
                 return (DiscogsFormat.Cd, format);
+            case "8track" or "8tracks" or "8-track cartridge":
+                return (DiscogsFormat.EightTrack, format);
             default:
                 return (DiscogsFormat.Miscellaneous, null);
         }

--- a/src/FMBot.Bot/Services/StringService.cs
+++ b/src/FMBot.Bot/Services/StringService.cs
@@ -387,6 +387,8 @@ public static class StringService
                 return "💿";
             case "Casette":
                 return "<:casette:1043890774384853012>";
+            case "8-Track Cartridge":
+                return "<:casette:1043890774384853012>";
         }
 
         return null;

--- a/src/FMBot.Domain/Enums/DiscogsFormat.cs
+++ b/src/FMBot.Domain/Enums/DiscogsFormat.cs
@@ -4,5 +4,6 @@ public enum DiscogsFormat {
     Vinyl,
     Cassette,
     Cd,
+    EightTrack,
     Miscellaneous,
 }


### PR DESCRIPTION
i'd like to move 8-track releases into its own category.

inspired by this post on discord: https://discord.com/channels/821660544581763093/1153679296922140704

---

despite me making this feature to begin with, i don't remember if it's simply this easy to add a format, haha.

discogs seems to use the following string for 8-track releases: "8-Track Cartridge". you can verify with this command, assuming you have curl and jq installed: `curl https://api.discogs.com/releases/14435971 --user-agent "FooBarApp/3.0" | jq .formats`

should return: 

```json
[
  {
    "name": "8-Track Cartridge",
    "qty": "12",
    "descriptions": [
      "Compilation",
      "Limited Edition",
      "Numbered",
      "Special Edition",
      "Stereo"
    ]
  }
]
```