### PR TITLE
Small argument, as discussed in .fmbot Discord help channel

### DIFF
--- a/src/FMBot.Bot/Builders/AlbumBuilders.cs
+++ b/src/FMBot.Bot/Builders/AlbumBuilders.cs
@@ -21,7 +21,6 @@ using FMBot.Domain.Extensions;
 using FMBot.Domain.Interfaces;
 using FMBot.Domain.Models;
 using FMBot.Images.Generators;
-using FMBot.LastFM.Repositories;
 using FMBot.Persistence.Domain.Models;
 using SkiaSharp;
 
@@ -191,7 +190,7 @@ public class AlbumBuilders
 
             var guildAlsoPlaying = this._whoKnowsPlayService.GuildAlsoPlayingAlbum(context.ContextUser.UserId,
             guildUsers, guild, albumSearch.Album.ArtistName, albumSearch.Album.AlbumName);
-             
+
             if (guildAlsoPlaying != null)
             {
                 footer.AppendLine(guildAlsoPlaying);
@@ -1133,8 +1132,7 @@ public class AlbumBuilders
             }
         }
 
-        var albumPages = albums.Content.TopAlbums
-            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+        var albumPages = albums.Content.TopAlbums.ChunkBy((int) topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -144,7 +144,8 @@ public class ArtistBuilders
 
                 firstListenInfo = $"Discovered on: <t:{firstListenValue}:D>";
             }
-        } else
+        }
+        else
         {
             var randomHintNumber = new Random().Next(0, Constants.SupporterPromoChance);
             if (randomHintNumber == 1 && this._supporterService.ShowPromotionalMessage(context.ContextUser.UserType, context.DiscordGuild?.Id))
@@ -168,7 +169,8 @@ public class ArtistBuilders
                     artistInfo.Append($"**{fullArtist.Disambiguation}**");
                     artistInfo.Append($" from **{fullArtist.Location}**");
                     artistInfo.AppendLine();
-                } else
+                }
+                else
                 {
                     artistInfo.AppendLine($"**{fullArtist.Disambiguation}**");
                 }
@@ -196,7 +198,8 @@ public class ArtistBuilders
                 if (fullArtist.Type?.ToLower() == "person")
                 {
                     artistInfo.AppendLine($"Born: <t:{dateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
-                } else
+                }
+                else
                 {
                     artistInfo.AppendLine($"Started: <t:{dateValue}:D>");
                 }
@@ -213,7 +216,8 @@ public class ArtistBuilders
                 {
                     artistInfo.AppendLine($"Born: <t:{startDateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
                     artistInfo.AppendLine($"Died: <t:{endDateValue}:D>");
-                } else
+                }
+                else
                 {
                     artistInfo.AppendLine($"Started: <t:{startDateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
                     artistInfo.AppendLine($"Stopped: <t:{endDateValue}:D>");
@@ -233,7 +237,8 @@ public class ArtistBuilders
                     response.Embed.WithDescription(
                         artistInfo + "\n" + response.Embed.Description);
 
-                } else
+                }
+                else
                 {
                     response.Embed.WithDescription(artistInfo.ToString());
                 }
@@ -277,7 +282,8 @@ public class ArtistBuilders
                 {
                     footer.AppendLine(guildAlsoPlaying);
                 }
-            } else
+            }
+            else
             {
                 serverStats += $"Run `{context.Prefix}index` to get server stats";
             }
@@ -434,7 +440,8 @@ public class ArtistBuilders
                 footer.AppendLine($"{userSettings.UserNameLastFm} has {artistSearch.Artist.UserPlaycount} total scrobbles on this artist");
                 footer.AppendLine($"Requested by {userTitle}");
                 title.Append($"{userSettings.DisplayName}'s top tracks for '{artistSearch.Artist.ArtistName}'");
-            } else
+            }
+            else
             {
                 footer.Append($"{userTitle} has {artistSearch.Artist.UserPlaycount} total scrobbles on this artist");
                 title.Append($"Your top tracks for '{artistSearch.Artist.ArtistName}'");
@@ -470,7 +477,8 @@ public class ArtistBuilders
         if (guildListSettings.ChartTimePeriod == TimePeriod.AllTime)
         {
             topGuildArtists = await this._whoKnowsArtistService.GetTopAllTimeArtistsForGuild(guild.GuildId, guildListSettings.OrderType);
-        } else
+        }
+        else
         {
             var plays = await this._playService.GetGuildUsersPlays(guild.GuildId,
                 guildListSettings.AmountOfDaysWithBillboard);
@@ -521,7 +529,8 @@ public class ArtistBuilders
                     int? previousPosition = previousTopArtist == null ? null : previousTopGuildArtists.IndexOf(previousTopArtist);
 
                     pageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition, false).Text);
-                } else
+                }
+                else
                 {
                     pageString.AppendLine(name);
                 }
@@ -567,7 +576,8 @@ public class ArtistBuilders
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        } else
+        }
+        else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -609,7 +619,7 @@ public class ArtistBuilders
             }
         }
 
-        var artistPages = artists.Content.TopArtists.ChunkBy((int) topListSettings.EmbedSize);
+        var artistPages = artists.Content.TopArtists.ChunkBy((int)topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -629,7 +639,8 @@ public class ArtistBuilders
                     int? previousPosition = previousTopArtist == null ? null : previousTopArtists.IndexOf(previousTopArtist);
 
                     artistPageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition).Text);
-                } else
+                }
+                else
                 {
                     artistPageString.Append($"{counter}. ");
                     artistPageString.AppendLine(name);
@@ -727,7 +738,8 @@ public class ArtistBuilders
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        } else
+        }
+        else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -761,7 +773,8 @@ public class ArtistBuilders
             .GroupBy(g => g.ArtistName, StringComparer.OrdinalIgnoreCase)
             .Select(s => new TopArtist
             {
-                ArtistName = s.Key, UserPlaycount = allArtists[s.Key],
+                ArtistName = s.Key,
+                UserPlaycount = allArtists[s.Key],
                 FirstPlay = s.OrderBy(o => o.TimePlayed).First().TimePlayed,
                 ArtistUrl = LastfmUrlExtensions.GetArtistUrl(s.Key)
             })
@@ -769,7 +782,7 @@ public class ArtistBuilders
             .OrderByDescending(o => o.UserPlaycount)
             .ToList();
 
-        var artistPages = topNewArtists.ChunkBy((int) topListSettings.EmbedSize);
+        var artistPages = topNewArtists.ChunkBy((int)topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -876,7 +889,8 @@ public class ArtistBuilders
         {
             reply.Append($"<@{context.DiscordUser.Id}> My estimate is that the user '{StringExtensions.Sanitize(userSettings.UserNameLastFm)}'");
             determiner = "their";
-        } else
+        }
+        else
         {
             reply.Append($"<@{context.DiscordUser.Id}> My estimate is that you");
         }
@@ -1040,7 +1054,8 @@ public class ArtistBuilders
                     .WithMaxValues(25);
 
                 response.Components = new ComponentBuilder().WithSelectMenu(allowedRoles);
-            } else
+            }
+            else
             {
                 //response.Components = new ComponentBuilder().WithButton(Constants.GetPremiumServer, disabled: true, customId: "1");
             }
@@ -1433,7 +1448,8 @@ public class ArtistBuilders
             artistPage.WithDescription(taste.Description);
             artistPage.AddField("Artist", taste.LeftDescription, true);
             artistPage.AddField("Plays", taste.RightDescription, true);
-        } else
+        }
+        else
         {
             var taste = this._artistsService.GetTableTaste(ownTopArtists, otherTopArtists, amount, timeSettings.TimePeriod, ownLastFmUsername, lastfmToCompare, "Artist");
 
@@ -1482,7 +1498,8 @@ public class ArtistBuilders
             {
                 countryPage.WithFooter("⬅️ Genres\n" +
                                        "➡️ Discogs");
-            } else
+            }
+            else
             {
                 countryPage.WithFooter("⬅️ Genres");
             }

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -1359,10 +1359,10 @@ public class ArtistBuilders
         if (lastfmToCompare.ToLower() == ownLastFmUsername)
         {
             response.Embed.WithDescription($"You can't compare your own taste with yourself. For viewing your top artists, use `{context.Prefix}topartists`.\n\n" +
-                                              $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
-                                              $"Examples:\n" +
-                                              $"- `{context.Prefix}taste fm-bot`\n" +
-                                              $"- `{context.Prefix}taste @.fmbot`");
+                                        $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
+                                        $"Examples:\n" +
+                                        $"- `{context.Prefix}taste fm-bot`\n" +
+                                        $"- `{context.Prefix}taste @.fmbot`");
             response.CommandResponse = CommandResponse.WrongInput;
             response.ResponseType = ResponseType.Embed;
             return response;

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -761,7 +761,9 @@ public class ArtistBuilders
             .GroupBy(g => g.ArtistName, StringComparer.OrdinalIgnoreCase)
             .Select(s => new TopArtist
             {
-                ArtistName = s.Key, UserPlaycount = allArtists[s.Key], FirstPlay = s.OrderBy(o => o.TimePlayed).First().TimePlayed, ArtistUrl = LastfmUrlExtensions.GetArtistUrl(s.Key)
+                ArtistName = s.Key, UserPlaycount = allArtists[s.Key],
+                FirstPlay = s.OrderBy(o => o.TimePlayed).First().TimePlayed,
+                ArtistUrl = LastfmUrlExtensions.GetArtistUrl(s.Key)
             })
             .Where(w => !knownArtists.Any(a => a.Equals(w.ArtistName, StringComparison.OrdinalIgnoreCase)))
             .OrderByDescending(o => o.UserPlaycount)

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -16,6 +16,7 @@ using FMBot.Bot.Services.Guild;
 using FMBot.Bot.Services.ThirdParty;
 using FMBot.Bot.Services.WhoKnows;
 using FMBot.Domain;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Extensions;
 using FMBot.Domain.Interfaces;
 using FMBot.Domain.Models;
@@ -143,8 +144,7 @@ public class ArtistBuilders
 
                 firstListenInfo = $"Discovered on: <t:{firstListenValue}:D>";
             }
-        }
-        else
+        } else
         {
             var randomHintNumber = new Random().Next(0, Constants.SupporterPromoChance);
             if (randomHintNumber == 1 && this._supporterService.ShowPromotionalMessage(context.ContextUser.UserType, context.DiscordGuild?.Id))
@@ -168,8 +168,7 @@ public class ArtistBuilders
                     artistInfo.Append($"**{fullArtist.Disambiguation}**");
                     artistInfo.Append($" from **{fullArtist.Location}**");
                     artistInfo.AppendLine();
-                }
-                else
+                } else
                 {
                     artistInfo.AppendLine($"**{fullArtist.Disambiguation}**");
                 }
@@ -197,8 +196,7 @@ public class ArtistBuilders
                 if (fullArtist.Type?.ToLower() == "person")
                 {
                     artistInfo.AppendLine($"Born: <t:{dateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
-                }
-                else
+                } else
                 {
                     artistInfo.AppendLine($"Started: <t:{dateValue}:D>");
                 }
@@ -215,8 +213,7 @@ public class ArtistBuilders
                 {
                     artistInfo.AppendLine($"Born: <t:{startDateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
                     artistInfo.AppendLine($"Died: <t:{endDateValue}:D>");
-                }
-                else
+                } else
                 {
                     artistInfo.AppendLine($"Started: <t:{startDateValue}:D> {ArtistsService.IsArtistBirthday(fullArtist.StartDate)}");
                     artistInfo.AppendLine($"Stopped: <t:{endDateValue}:D>");
@@ -236,8 +233,7 @@ public class ArtistBuilders
                     response.Embed.WithDescription(
                         artistInfo + "\n" + response.Embed.Description);
 
-                }
-                else
+                } else
                 {
                     response.Embed.WithDescription(artistInfo.ToString());
                 }
@@ -281,8 +277,7 @@ public class ArtistBuilders
                 {
                     footer.AppendLine(guildAlsoPlaying);
                 }
-            }
-            else
+            } else
             {
                 serverStats += $"Run `{context.Prefix}index` to get server stats";
             }
@@ -439,8 +434,7 @@ public class ArtistBuilders
                 footer.AppendLine($"{userSettings.UserNameLastFm} has {artistSearch.Artist.UserPlaycount} total scrobbles on this artist");
                 footer.AppendLine($"Requested by {userTitle}");
                 title.Append($"{userSettings.DisplayName}'s top tracks for '{artistSearch.Artist.ArtistName}'");
-            }
-            else
+            } else
             {
                 footer.Append($"{userTitle} has {artistSearch.Artist.UserPlaycount} total scrobbles on this artist");
                 title.Append($"Your top tracks for '{artistSearch.Artist.ArtistName}'");
@@ -476,8 +470,7 @@ public class ArtistBuilders
         if (guildListSettings.ChartTimePeriod == TimePeriod.AllTime)
         {
             topGuildArtists = await this._whoKnowsArtistService.GetTopAllTimeArtistsForGuild(guild.GuildId, guildListSettings.OrderType);
-        }
-        else
+        } else
         {
             var plays = await this._playService.GetGuildUsersPlays(guild.GuildId,
                 guildListSettings.AmountOfDaysWithBillboard);
@@ -528,8 +521,7 @@ public class ArtistBuilders
                     int? previousPosition = previousTopArtist == null ? null : previousTopGuildArtists.IndexOf(previousTopArtist);
 
                     pageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition, false).Text);
-                }
-                else
+                } else
                 {
                     pageString.AppendLine(name);
                 }
@@ -575,8 +567,7 @@ public class ArtistBuilders
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        }
-        else
+        } else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -618,8 +609,7 @@ public class ArtistBuilders
             }
         }
 
-        var artistPages = artists.Content.TopArtists
-            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+        var artistPages = artists.Content.TopArtists.ChunkBy((int) topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -639,8 +629,7 @@ public class ArtistBuilders
                     int? previousPosition = previousTopArtist == null ? null : previousTopArtists.IndexOf(previousTopArtist);
 
                     artistPageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition).Text);
-                }
-                else
+                } else
                 {
                     artistPageString.Append($"{counter}. ");
                     artistPageString.AppendLine(name);
@@ -738,8 +727,7 @@ public class ArtistBuilders
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        }
-        else
+        } else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -773,17 +761,13 @@ public class ArtistBuilders
             .GroupBy(g => g.ArtistName, StringComparer.OrdinalIgnoreCase)
             .Select(s => new TopArtist
             {
-                ArtistName = s.Key,
-                UserPlaycount = allArtists[s.Key],
-                FirstPlay = s.OrderBy(o => o.TimePlayed).First().TimePlayed,
-                ArtistUrl = LastfmUrlExtensions.GetArtistUrl(s.Key)
+                ArtistName = s.Key, UserPlaycount = allArtists[s.Key], FirstPlay = s.OrderBy(o => o.TimePlayed).First().TimePlayed, ArtistUrl = LastfmUrlExtensions.GetArtistUrl(s.Key)
             })
             .Where(w => !knownArtists.Any(a => a.Equals(w.ArtistName, StringComparison.OrdinalIgnoreCase)))
             .OrderByDescending(o => o.UserPlaycount)
             .ToList();
 
-        var artistPages = topNewArtists
-            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+        var artistPages = topNewArtists.ChunkBy((int) topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -890,8 +874,7 @@ public class ArtistBuilders
         {
             reply.Append($"<@{context.DiscordUser.Id}> My estimate is that the user '{StringExtensions.Sanitize(userSettings.UserNameLastFm)}'");
             determiner = "their";
-        }
-        else
+        } else
         {
             reply.Append($"<@{context.DiscordUser.Id}> My estimate is that you");
         }
@@ -1055,8 +1038,7 @@ public class ArtistBuilders
                     .WithMaxValues(25);
 
                 response.Components = new ComponentBuilder().WithSelectMenu(allowedRoles);
-            }
-            else
+            } else
             {
                 //response.Components = new ComponentBuilder().WithButton(Constants.GetPremiumServer, disabled: true, customId: "1");
             }
@@ -1350,9 +1332,9 @@ public class ArtistBuilders
         if (lastfmToCompare == null)
         {
             response.Embed.WithDescription($"Please enter a valid Last.fm username or mention someone to compare yourself to.\n" +
-                                        $"Examples:\n" +
-                                        $"- `{context.Prefix}taste fm-bot`\n" +
-                                        $"- `{context.Prefix}taste @.fmbot`");
+                                           $"Examples:\n" +
+                                           $"- `{context.Prefix}taste fm-bot`\n" +
+                                           $"- `{context.Prefix}taste @.fmbot`");
             response.CommandResponse = CommandResponse.WrongInput;
             response.ResponseType = ResponseType.Embed;
             return response;
@@ -1360,10 +1342,10 @@ public class ArtistBuilders
         if (lastfmToCompare.ToLower() == ownLastFmUsername)
         {
             response.Embed.WithDescription($"You can't compare your own taste with yourself. For viewing your top artists, use `{context.Prefix}topartists`.\n\n" +
-                                        $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
-                                        $"Examples:\n" +
-                                        $"- `{context.Prefix}taste fm-bot`\n" +
-                                        $"- `{context.Prefix}taste @.fmbot`");
+                                           $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
+                                           $"Examples:\n" +
+                                           $"- `{context.Prefix}taste fm-bot`\n" +
+                                           $"- `{context.Prefix}taste @.fmbot`");
             response.CommandResponse = CommandResponse.WrongInput;
             response.ResponseType = ResponseType.Embed;
             return response;
@@ -1399,7 +1381,14 @@ public class ArtistBuilders
             return response;
         }
 
-        var amount = tasteSettings.ExtraLarge ? 28 : 14;
+
+        var amount = tasteSettings.EmbedSize switch
+        {
+            EmbedSize.Default => 14,
+            EmbedSize.Small => 7,
+            EmbedSize.Large => 28,
+            _ => 14
+        };
         var pages = new List<PageBuilder>();
 
         var url = LastfmUrlExtensions.GetUserUrl(lastfmToCompare, $"/library/artists?{timeSettings.UrlParameter}");
@@ -1442,8 +1431,7 @@ public class ArtistBuilders
             artistPage.WithDescription(taste.Description);
             artistPage.AddField("Artist", taste.LeftDescription, true);
             artistPage.AddField("Plays", taste.RightDescription, true);
-        }
-        else
+        } else
         {
             var taste = this._artistsService.GetTableTaste(ownTopArtists, otherTopArtists, amount, timeSettings.TimePeriod, ownLastFmUsername, lastfmToCompare, "Artist");
 
@@ -1468,7 +1456,7 @@ public class ArtistBuilders
 
             genrePage.WithDescription(taste.result);
             genrePage.WithFooter("⬅️ Artists\n" +
-                                  "➡️ Countries");
+                                 "➡️ Countries");
 
             pages.Add(genrePage);
         }
@@ -1491,9 +1479,8 @@ public class ArtistBuilders
             if (willCreateDiscogsPage)
             {
                 countryPage.WithFooter("⬅️ Genres\n" +
-                                        "➡️ Discogs");
-            }
-            else
+                                       "➡️ Discogs");
+            } else
             {
                 countryPage.WithFooter("⬅️ Genres");
             }
@@ -1615,9 +1602,9 @@ public class ArtistBuilders
                 pageString.AppendLine(
                     $"**{(neighbor.Value.TotalPoints / self.TotalPoints).ToString("P1", numberInfo)}** — " +
                     $"**[{StringExtensions.Sanitize(guildUser?.UserName)}]({LastfmUrlExtensions.GetUserUrl(guildUser?.UserNameLastFM)})** — " +
-                                      $"`{(neighbor.Value.ArtistPoints / self.ArtistPoints).ToString("P0", numberInfo)}` artists, " +
-                                      $"`{(neighbor.Value.GenrePoints / self.GenrePoints).ToString("P0", numberInfo)}` genres, " +
-                                      $"`{(neighbor.Value.CountryPoints / self.CountryPoints).ToString("P0", numberInfo)}` countries");
+                    $"`{(neighbor.Value.ArtistPoints / self.ArtistPoints).ToString("P0", numberInfo)}` artists, " +
+                    $"`{(neighbor.Value.GenrePoints / self.GenrePoints).ToString("P0", numberInfo)}` genres, " +
+                    $"`{(neighbor.Value.CountryPoints / self.CountryPoints).ToString("P0", numberInfo)}` countries");
 
             }
 

--- a/src/FMBot.Bot/Builders/ArtistBuilders.cs
+++ b/src/FMBot.Bot/Builders/ArtistBuilders.cs
@@ -1349,9 +1349,9 @@ public class ArtistBuilders
         if (lastfmToCompare == null)
         {
             response.Embed.WithDescription($"Please enter a valid Last.fm username or mention someone to compare yourself to.\n" +
-                                           $"Examples:\n" +
-                                           $"- `{context.Prefix}taste fm-bot`\n" +
-                                           $"- `{context.Prefix}taste @.fmbot`");
+                                        $"Examples:\n" +
+                                        $"- `{context.Prefix}taste fm-bot`\n" +
+                                        $"- `{context.Prefix}taste @.fmbot`");
             response.CommandResponse = CommandResponse.WrongInput;
             response.ResponseType = ResponseType.Embed;
             return response;
@@ -1359,10 +1359,10 @@ public class ArtistBuilders
         if (lastfmToCompare.ToLower() == ownLastFmUsername)
         {
             response.Embed.WithDescription($"You can't compare your own taste with yourself. For viewing your top artists, use `{context.Prefix}topartists`.\n\n" +
-                                           $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
-                                           $"Examples:\n" +
-                                           $"- `{context.Prefix}taste fm-bot`\n" +
-                                           $"- `{context.Prefix}taste @.fmbot`");
+                                              $"Please enter a Last.fm username or mention someone to compare yourself to.\n" +
+                                              $"Examples:\n" +
+                                              $"- `{context.Prefix}taste fm-bot`\n" +
+                                              $"- `{context.Prefix}taste @.fmbot`");
             response.CommandResponse = CommandResponse.WrongInput;
             response.ResponseType = ResponseType.Embed;
             return response;
@@ -1474,7 +1474,7 @@ public class ArtistBuilders
 
             genrePage.WithDescription(taste.result);
             genrePage.WithFooter("⬅️ Artists\n" +
-                                 "➡️ Countries");
+                                  "➡️ Countries");
 
             pages.Add(genrePage);
         }
@@ -1497,7 +1497,7 @@ public class ArtistBuilders
             if (willCreateDiscogsPage)
             {
                 countryPage.WithFooter("⬅️ Genres\n" +
-                                       "➡️ Discogs");
+                                        "➡️ Discogs");
             }
             else
             {
@@ -1621,9 +1621,9 @@ public class ArtistBuilders
                 pageString.AppendLine(
                     $"**{(neighbor.Value.TotalPoints / self.TotalPoints).ToString("P1", numberInfo)}** — " +
                     $"**[{StringExtensions.Sanitize(guildUser?.UserName)}]({LastfmUrlExtensions.GetUserUrl(guildUser?.UserNameLastFM)})** — " +
-                    $"`{(neighbor.Value.ArtistPoints / self.ArtistPoints).ToString("P0", numberInfo)}` artists, " +
-                    $"`{(neighbor.Value.GenrePoints / self.GenrePoints).ToString("P0", numberInfo)}` genres, " +
-                    $"`{(neighbor.Value.CountryPoints / self.CountryPoints).ToString("P0", numberInfo)}` countries");
+                                      $"`{(neighbor.Value.ArtistPoints / self.ArtistPoints).ToString("P0", numberInfo)}` artists, " +
+                                      $"`{(neighbor.Value.GenrePoints / self.GenrePoints).ToString("P0", numberInfo)}` genres, " +
+                                      $"`{(neighbor.Value.CountryPoints / self.CountryPoints).ToString("P0", numberInfo)}` countries");
 
             }
 

--- a/src/FMBot.Bot/Builders/CountryBuilders.cs
+++ b/src/FMBot.Bot/Builders/CountryBuilders.cs
@@ -10,6 +10,7 @@ using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.ThirdParty;
 using FMBot.Domain;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Extensions;
 using FMBot.Domain.Interfaces;
 using FMBot.Domain.Models;
@@ -323,9 +324,7 @@ public class CountryBuilders
         var countries = await this._countryService.GetTopCountriesForTopArtists(artists.Content.TopArtists, true);
         var previousTopCountries = await this._countryService.GetTopCountriesForTopArtists(previousTopArtists, true);
 
-        var countryPages = countries.ChunkBy(topListSettings.ExtraLarge
-            ? Constants.DefaultExtraLargePageSize
-            : Constants.DefaultPageSize);
+        var countryPages = countries.ChunkBy((int) topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -43,8 +43,8 @@ public class DiscogsBuilder
         var discogsAuth = await this._discogsService.GetDiscogsAuthLink();
 
         response.Embed.WithDescription($"**[Click here to login to Discogs.]({discogsAuth.LoginUrl})**\n\n" +
-                                       $"After authorizing .fmbot a code will be shown.\n" +
-                                       $"**Copy the code and send it in this chat.**");
+                                    $"After authorizing .fmbot a code will be shown.\n" +
+                                    $"**Copy the code and send it in this chat.**");
         response.Embed.WithFooter($"Do not share the code outside of this DM conversation");
         response.Embed.WithColor(DiscordConstants.InformationColorBlue);
 
@@ -66,7 +66,7 @@ public class DiscogsBuilder
             {
                 m.Embed = new EmbedBuilder()
                     .WithDescription($"❌ Login failed.. link timed out.\n\n" +
-                                     $"Re-run the `{context.Prefix}discogs` command to try again.")
+                                        $"Re-run the `{context.Prefix}discogs` command to try again.")
                     .WithColor(DiscordConstants.WarningColorOrange)
                     .Build();
             });
@@ -77,7 +77,7 @@ public class DiscogsBuilder
         if (result.Value?.Content == null || !Regex.IsMatch(result.Value.Content, @"^[a-zA-Z]+$") || result.Value.Content.Length != 10)
         {
             response.Embed.WithDescription($"Login failed, incorrect input.\n\n" +
-                                           $"Re-run the `{context.Prefix}discogs` command to try again.");
+                                        $"Re-run the `{context.Prefix}discogs` command to try again.");
             response.Embed.WithColor(DiscordConstants.WarningColorOrange);
             response.CommandResponse = CommandResponse.WrongInput;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
@@ -91,14 +91,14 @@ public class DiscogsBuilder
             await this._discogsService.StoreDiscogsAuth(context.ContextUser.UserId, user.Auth, user.Identity);
 
             response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}]({Constants.DiscogsUserUrl}{user.Identity.Username})' has been connected.\n" +
-                                           $"Run the `{context.Prefix}collection` command to view your collection.");
+                                        $"Run the `{context.Prefix}collection` command to view your collection.");
             response.CommandResponse = CommandResponse.Ok;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
         }
         else
         {
             response.Embed.WithDescription($"Could not connect a Discogs account with provided code.\n\n" +
-                                           $"Re-run the `{context.Prefix}discogs` command to try again.");
+                                        $"Re-run the `{context.Prefix}discogs` command to try again.");
             response.Embed.WithColor(DiscordConstants.WarningColorOrange);
             response.CommandResponse = CommandResponse.WrongInput;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -12,6 +12,7 @@ using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.ThirdParty;
 using FMBot.Domain;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Models;
 using static SpotifyAPI.Web.PlaylistRemoveItemsRequest;
 
@@ -42,8 +43,8 @@ public class DiscogsBuilder
         var discogsAuth = await this._discogsService.GetDiscogsAuthLink();
 
         response.Embed.WithDescription($"**[Click here to login to Discogs.]({discogsAuth.LoginUrl})**\n\n" +
-                                    $"After authorizing .fmbot a code will be shown.\n" +
-                                    $"**Copy the code and send it in this chat.**");
+                                       $"After authorizing .fmbot a code will be shown.\n" +
+                                       $"**Copy the code and send it in this chat.**");
         response.Embed.WithFooter($"Do not share the code outside of this DM conversation");
         response.Embed.WithColor(DiscordConstants.InformationColorBlue);
 
@@ -65,7 +66,7 @@ public class DiscogsBuilder
             {
                 m.Embed = new EmbedBuilder()
                     .WithDescription($"❌ Login failed.. link timed out.\n\n" +
-                                        $"Re-run the `{context.Prefix}discogs` command to try again.")
+                                     $"Re-run the `{context.Prefix}discogs` command to try again.")
                     .WithColor(DiscordConstants.WarningColorOrange)
                     .Build();
             });
@@ -76,7 +77,7 @@ public class DiscogsBuilder
         if (result.Value?.Content == null || !Regex.IsMatch(result.Value.Content, @"^[a-zA-Z]+$") || result.Value.Content.Length != 10)
         {
             response.Embed.WithDescription($"Login failed, incorrect input.\n\n" +
-                                        $"Re-run the `{context.Prefix}discogs` command to try again.");
+                                           $"Re-run the `{context.Prefix}discogs` command to try again.");
             response.Embed.WithColor(DiscordConstants.WarningColorOrange);
             response.CommandResponse = CommandResponse.WrongInput;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
@@ -90,14 +91,13 @@ public class DiscogsBuilder
             await this._discogsService.StoreDiscogsAuth(context.ContextUser.UserId, user.Auth, user.Identity);
 
             response.Embed.WithDescription($"✅ Your Discogs account '[{user.Identity.Username}]({Constants.DiscogsUserUrl}{user.Identity.Username})' has been connected.\n" +
-                                        $"Run the `{context.Prefix}collection` command to view your collection.");
+                                           $"Run the `{context.Prefix}collection` command to view your collection.");
             response.CommandResponse = CommandResponse.Ok;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
-        }
-        else
+        } else
         {
             response.Embed.WithDescription($"Could not connect a Discogs account with provided code.\n\n" +
-                                        $"Re-run the `{context.Prefix}discogs` command to try again.");
+                                           $"Re-run the `{context.Prefix}discogs` command to try again.");
             response.Embed.WithColor(DiscordConstants.WarningColorOrange);
             response.CommandResponse = CommandResponse.WrongInput;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
@@ -124,8 +124,7 @@ public class DiscogsBuilder
             {
                 response.Embed.WithDescription("To use the Discogs commands you have to connect a Discogs account.\n\n" +
                                                $"Use the `{context.Prefix}discogs` command to get started.");
-            }
-            else
+            } else
             {
                 response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
             }
@@ -213,8 +212,7 @@ public class DiscogsBuilder
             if (justUpdated)
             {
                 footer.AppendLine("Last update just now - Updates max once per hour");
-            }
-            else
+            } else
             {
                 var diff = DateTime.UtcNow - user.UserDiscogs.ReleasesLastUpdated;
 
@@ -268,8 +266,7 @@ public class DiscogsBuilder
             {
                 response.Embed.WithDescription("To use the top artists commands with Discogs you have to connect a Discogs account.\n\n" +
                                                $"Use the `{context.Prefix}discogs` command to get started.");
-            }
-            else
+            } else
             {
                 response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
             }
@@ -295,8 +292,7 @@ public class DiscogsBuilder
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        }
-        else
+        } else
         {
             userTitle =
                 $"{user.UserDiscogs.Username}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -322,7 +318,7 @@ public class DiscogsBuilder
         }
 
         var artistPages = topArtists.OrderByDescending(s => s.UserReleasesInCollection).ToList()
-            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+            .ChunkBy((int)topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;

--- a/src/FMBot.Bot/Builders/DiscogsBuilder.cs
+++ b/src/FMBot.Bot/Builders/DiscogsBuilder.cs
@@ -94,7 +94,8 @@ public class DiscogsBuilder
                                            $"Run the `{context.Prefix}collection` command to view your collection.");
             response.CommandResponse = CommandResponse.Ok;
             await context.DiscordUser.SendMessageAsync("", false, response.Embed.Build());
-        } else
+        }
+        else
         {
             response.Embed.WithDescription($"Could not connect a Discogs account with provided code.\n\n" +
                                            $"Re-run the `{context.Prefix}discogs` command to try again.");
@@ -124,7 +125,8 @@ public class DiscogsBuilder
             {
                 response.Embed.WithDescription("To use the Discogs commands you have to connect a Discogs account.\n\n" +
                                                $"Use the `{context.Prefix}discogs` command to get started.");
-            } else
+            }
+            else
             {
                 response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
             }
@@ -212,7 +214,8 @@ public class DiscogsBuilder
             if (justUpdated)
             {
                 footer.AppendLine("Last update just now - Updates max once per hour");
-            } else
+            }
+            else
             {
                 var diff = DateTime.UtcNow - user.UserDiscogs.ReleasesLastUpdated;
 
@@ -266,7 +269,8 @@ public class DiscogsBuilder
             {
                 response.Embed.WithDescription("To use the top artists commands with Discogs you have to connect a Discogs account.\n\n" +
                                                $"Use the `{context.Prefix}discogs` command to get started.");
-            } else
+            }
+            else
             {
                 response.Embed.WithDescription("The user you're trying to look up has not setup their Discogs account yet.");
             }
@@ -292,7 +296,8 @@ public class DiscogsBuilder
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
             userTitle = await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser);
-        } else
+        }
+        else
         {
             userTitle =
                 $"{user.UserDiscogs.Username}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";

--- a/src/FMBot.Bot/Builders/GenreBuilders.cs
+++ b/src/FMBot.Bot/Builders/GenreBuilders.cs
@@ -232,7 +232,7 @@ public class GenreBuilders
         var genres = await this._genreService.GetTopGenresForTopArtists(artists.Content.TopArtists);
         var previousTopGenres = await this._genreService.GetTopGenresForTopArtists(previousTopArtists);
 
-        var genrePages = genres.ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+        var genrePages = genres.ChunkBy((int) topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;

--- a/src/FMBot.Bot/Builders/TrackBuilders.cs
+++ b/src/FMBot.Bot/Builders/TrackBuilders.cs
@@ -182,7 +182,8 @@ public class TrackBuilders
 
                 response.Embed.WithDescription($"Discovered on: <t:{firstListenValue}:D>");
             }
-        } else
+        }
+        else
         {
             var randomHintNumber = new Random().Next(0, Constants.SupporterPromoChance);
             if (randomHintNumber == 1 && this._supporterService.ShowPromotionalMessage(context.ContextUser.UserType, context.DiscordGuild?.Id))
@@ -345,7 +346,8 @@ public class TrackBuilders
                     .WithMaxValues(25);
 
                 response.Components = new ComponentBuilder().WithSelectMenu(allowedRoles);
-            } else
+            }
+            else
             {
                 //response.Components = new ComponentBuilder().WithButton(Constants.GetPremiumServer, disabled: true, customId: "1");
             }
@@ -600,7 +602,8 @@ public class TrackBuilders
             if (safeForChannel == CensorService.CensorResult.Safe)
             {
                 response.Embed.WithThumbnailUrl(albumCoverUrl);
-            } else
+            }
+            else
             {
                 albumCoverUrl = null;
             }
@@ -672,7 +675,8 @@ public class TrackBuilders
         {
             response.Embed.WithTitle($"❤️ Track already loved");
             response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-        } else
+        }
+        else
         {
             var trackLoved = await this._dataSourceFactory.LoveTrackAsync(context.ContextUser.SessionKeyLastFm, trackSearch.Track.ArtistName, trackSearch.Track.TrackName);
 
@@ -680,7 +684,8 @@ public class TrackBuilders
             {
                 response.Embed.WithTitle($"❤️ Loved track for {userTitle}");
                 response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-            } else
+            }
+            else
             {
                 response.Text = "Something went wrong while adding loved track.";
                 response.ResponseType = ResponseType.Text;
@@ -713,7 +718,8 @@ public class TrackBuilders
         {
             response.Embed.WithTitle($"💔 Track wasn't loved");
             response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-        } else
+        }
+        else
         {
             var trackLoved = await this._dataSourceFactory.UnLoveTrackAsync(context.ContextUser.SessionKeyLastFm, trackSearch.Track.ArtistName, trackSearch.Track.TrackName);
 
@@ -721,7 +727,8 @@ public class TrackBuilders
             {
                 response.Embed.WithTitle($"💔 Unloved track for {userTitle}");
                 response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-            } else
+            }
+            else
             {
                 response.Text = "Something went wrong while unloving track.";
                 response.ResponseType = ResponseType.Text;
@@ -748,7 +755,8 @@ public class TrackBuilders
         if (guildListSettings.ChartTimePeriod == TimePeriod.AllTime)
         {
             topGuildTracks = await this._whoKnowsTrackService.GetTopAllTimeTracksForGuild(guild.GuildId, guildListSettings.OrderType, guildListSettings.NewSearchValue);
-        } else
+        }
+        else
         {
             var plays = await this._playService.GetGuildUsersPlays(guild.GuildId, guildListSettings.AmountOfDaysWithBillboard);
 
@@ -810,7 +818,8 @@ public class TrackBuilders
                     int? previousPosition = previousTopTrack == null ? null : previousTopGuildTracks.IndexOf(previousTopTrack);
 
                     pageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition, false).Text);
-                } else
+                }
+                else
                 {
                     pageString.AppendLine(name);
                 }
@@ -856,7 +865,8 @@ public class TrackBuilders
             {
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
-        } else
+        }
+        else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -927,7 +937,8 @@ public class TrackBuilders
                 if (!tooMuchChars)
                 {
                     name.Append($"**{StringExtensions.Sanitize(track.ArtistName)}** - **[{track.TrackName}]({track.TrackUrl})** ");
-                } else
+                }
+                else
                 {
                     name.Append($"**{StringExtensions.Sanitize(track.ArtistName)}** - **{track.TrackName}** ");
                 }
@@ -936,7 +947,8 @@ public class TrackBuilders
                 {
                     name.Append(
                         $"- *{track.UserPlaycount} {StringExtensions.GetPlaysString(track.UserPlaycount)}*");
-                } else
+                }
+                else
                 {
                     name.Append(
                         $"- *{StringExtensions.GetListeningTimeString(track.TimeListened.TotalTimeListened)}*");
@@ -948,7 +960,8 @@ public class TrackBuilders
                     int? previousPosition = previousTopTrack == null ? null : previousTopTracks.IndexOf(previousTopTrack);
 
                     trackPageString.AppendLine(StringService.GetBillboardLine(name.ToString(), counter - 1, previousPosition).Text);
-                } else
+                }
+                else
                 {
                     trackPageString.Append($"{counter}. ");
                     trackPageString.AppendLine(name.ToString());

--- a/src/FMBot.Bot/Builders/TrackBuilders.cs
+++ b/src/FMBot.Bot/Builders/TrackBuilders.cs
@@ -622,8 +622,7 @@ public class TrackBuilders
             ResponseType = ResponseType.Text,
         };
 
-        var trackSearch = await this._trackService.SearchTrack(response, context.DiscordUser, searchValue, context.ContextUser.UserNameLastFM, context.ContextUser.SessionKeyLastFm,
-            otherUserUsername: userSettings.UserNameLastFm, userId: context.ContextUser.UserId);
+        var trackSearch = await this._trackService.SearchTrack(response, context.DiscordUser, searchValue, context.ContextUser.UserNameLastFM, context.ContextUser.SessionKeyLastFm, otherUserUsername: userSettings.UserNameLastFm, userId: context.ContextUser.UserId);
         if (trackSearch.Track == null)
         {
             return trackSearch.Response;
@@ -774,9 +773,9 @@ public class TrackBuilders
             return response;
         }
 
-        var title = string.IsNullOrWhiteSpace(guildListSettings.NewSearchValue)
-            ? $"Top {guildListSettings.TimeDescription.ToLower()} tracks in {context.DiscordGuild.Name}"
-            : $"Top {guildListSettings.TimeDescription.ToLower()} '{guildListSettings.NewSearchValue}' tracks in {context.DiscordGuild.Name}";
+        var title = string.IsNullOrWhiteSpace(guildListSettings.NewSearchValue) ?
+            $"Top {guildListSettings.TimeDescription.ToLower()} tracks in {context.DiscordGuild.Name}" :
+            $"Top {guildListSettings.TimeDescription.ToLower()} '{guildListSettings.NewSearchValue}' tracks in {context.DiscordGuild.Name}";
 
         var footer = new StringBuilder();
         footer.AppendLine(guildListSettings.OrderType == OrderType.Listeners
@@ -898,8 +897,7 @@ public class TrackBuilders
         if (topListSettings.Billboard && timeSettings.BillboardStartDateTime.HasValue && timeSettings.BillboardEndDateTime.HasValue)
         {
             var previousTopTracksCall = await this._dataSourceFactory
-                .GetTopTracksForCustomTimePeriodAsyncAsync(userSettings.UserNameLastFm, timeSettings.BillboardStartDateTime.Value, timeSettings.BillboardEndDateTime.Value, 200,
-                    calculateTimeListened: topListSettings.Type == TopListType.TimeListened);
+                .GetTopTracksForCustomTimePeriodAsyncAsync(userSettings.UserNameLastFm, timeSettings.BillboardStartDateTime.Value, timeSettings.BillboardEndDateTime.Value, 200, calculateTimeListened: topListSettings.Type == TopListType.TimeListened);
 
             if (previousTopTracksCall.Success)
             {
@@ -920,7 +918,8 @@ public class TrackBuilders
                 .ToList();
         }
 
-        var trackPages = topTracks.Content.TopTracks.ChunkBy((int)topListSettings.EmbedSize);
+        var trackPages = topTracks.Content.TopTracks.
+            ChunkBy((int)topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -1054,4 +1053,6 @@ public class TrackBuilders
 
         return response;
     }
+
+
 }

--- a/src/FMBot.Bot/Builders/TrackBuilders.cs
+++ b/src/FMBot.Bot/Builders/TrackBuilders.cs
@@ -182,8 +182,7 @@ public class TrackBuilders
 
                 response.Embed.WithDescription($"Discovered on: <t:{firstListenValue}:D>");
             }
-        }
-        else
+        } else
         {
             var randomHintNumber = new Random().Next(0, Constants.SupporterPromoChance);
             if (randomHintNumber == 1 && this._supporterService.ShowPromotionalMessage(context.ContextUser.UserType, context.DiscordGuild?.Id))
@@ -346,8 +345,7 @@ public class TrackBuilders
                     .WithMaxValues(25);
 
                 response.Components = new ComponentBuilder().WithSelectMenu(allowedRoles);
-            }
-            else
+            } else
             {
                 //response.Components = new ComponentBuilder().WithButton(Constants.GetPremiumServer, disabled: true, customId: "1");
             }
@@ -602,8 +600,7 @@ public class TrackBuilders
             if (safeForChannel == CensorService.CensorResult.Safe)
             {
                 response.Embed.WithThumbnailUrl(albumCoverUrl);
-            }
-            else
+            } else
             {
                 albumCoverUrl = null;
             }
@@ -622,7 +619,8 @@ public class TrackBuilders
             ResponseType = ResponseType.Text,
         };
 
-        var trackSearch = await this._trackService.SearchTrack(response, context.DiscordUser, searchValue, context.ContextUser.UserNameLastFM, context.ContextUser.SessionKeyLastFm, otherUserUsername: userSettings.UserNameLastFm, userId: context.ContextUser.UserId);
+        var trackSearch = await this._trackService.SearchTrack(response, context.DiscordUser, searchValue, context.ContextUser.UserNameLastFM, context.ContextUser.SessionKeyLastFm,
+            otherUserUsername: userSettings.UserNameLastFm, userId: context.ContextUser.UserId);
         if (trackSearch.Track == null)
         {
             return trackSearch.Response;
@@ -674,8 +672,7 @@ public class TrackBuilders
         {
             response.Embed.WithTitle($"❤️ Track already loved");
             response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-        }
-        else
+        } else
         {
             var trackLoved = await this._dataSourceFactory.LoveTrackAsync(context.ContextUser.SessionKeyLastFm, trackSearch.Track.ArtistName, trackSearch.Track.TrackName);
 
@@ -683,8 +680,7 @@ public class TrackBuilders
             {
                 response.Embed.WithTitle($"❤️ Loved track for {userTitle}");
                 response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-            }
-            else
+            } else
             {
                 response.Text = "Something went wrong while adding loved track.";
                 response.ResponseType = ResponseType.Text;
@@ -717,8 +713,7 @@ public class TrackBuilders
         {
             response.Embed.WithTitle($"💔 Track wasn't loved");
             response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-        }
-        else
+        } else
         {
             var trackLoved = await this._dataSourceFactory.UnLoveTrackAsync(context.ContextUser.SessionKeyLastFm, trackSearch.Track.ArtistName, trackSearch.Track.TrackName);
 
@@ -726,8 +721,7 @@ public class TrackBuilders
             {
                 response.Embed.WithTitle($"💔 Unloved track for {userTitle}");
                 response.Embed.WithDescription(LastFmRepository.ResponseTrackToLinkedString(trackSearch.Track));
-            }
-            else
+            } else
             {
                 response.Text = "Something went wrong while unloving track.";
                 response.ResponseType = ResponseType.Text;
@@ -754,8 +748,7 @@ public class TrackBuilders
         if (guildListSettings.ChartTimePeriod == TimePeriod.AllTime)
         {
             topGuildTracks = await this._whoKnowsTrackService.GetTopAllTimeTracksForGuild(guild.GuildId, guildListSettings.OrderType, guildListSettings.NewSearchValue);
-        }
-        else
+        } else
         {
             var plays = await this._playService.GetGuildUsersPlays(guild.GuildId, guildListSettings.AmountOfDaysWithBillboard);
 
@@ -773,9 +766,9 @@ public class TrackBuilders
             return response;
         }
 
-        var title = string.IsNullOrWhiteSpace(guildListSettings.NewSearchValue) ?
-            $"Top {guildListSettings.TimeDescription.ToLower()} tracks in {context.DiscordGuild.Name}" :
-            $"Top {guildListSettings.TimeDescription.ToLower()} '{guildListSettings.NewSearchValue}' tracks in {context.DiscordGuild.Name}";
+        var title = string.IsNullOrWhiteSpace(guildListSettings.NewSearchValue)
+            ? $"Top {guildListSettings.TimeDescription.ToLower()} tracks in {context.DiscordGuild.Name}"
+            : $"Top {guildListSettings.TimeDescription.ToLower()} '{guildListSettings.NewSearchValue}' tracks in {context.DiscordGuild.Name}";
 
         var footer = new StringBuilder();
         footer.AppendLine(guildListSettings.OrderType == OrderType.Listeners
@@ -817,8 +810,7 @@ public class TrackBuilders
                     int? previousPosition = previousTopTrack == null ? null : previousTopGuildTracks.IndexOf(previousTopTrack);
 
                     pageString.AppendLine(StringService.GetBillboardLine(name, counter - 1, previousPosition, false).Text);
-                }
-                else
+                } else
                 {
                     pageString.AppendLine(name);
                 }
@@ -864,8 +856,7 @@ public class TrackBuilders
             {
                 response.EmbedAuthor.WithIconUrl(context.DiscordUser.GetAvatarUrl());
             }
-        }
-        else
+        } else
         {
             userTitle =
                 $"{userSettings.UserNameLastFm}, requested by {await this._userService.GetUserTitleAsync(context.DiscordGuild, context.DiscordUser)}";
@@ -897,7 +888,8 @@ public class TrackBuilders
         if (topListSettings.Billboard && timeSettings.BillboardStartDateTime.HasValue && timeSettings.BillboardEndDateTime.HasValue)
         {
             var previousTopTracksCall = await this._dataSourceFactory
-                .GetTopTracksForCustomTimePeriodAsyncAsync(userSettings.UserNameLastFm, timeSettings.BillboardStartDateTime.Value, timeSettings.BillboardEndDateTime.Value, 200, calculateTimeListened: topListSettings.Type == TopListType.TimeListened);
+                .GetTopTracksForCustomTimePeriodAsyncAsync(userSettings.UserNameLastFm, timeSettings.BillboardStartDateTime.Value, timeSettings.BillboardEndDateTime.Value, 200,
+                    calculateTimeListened: topListSettings.Type == TopListType.TimeListened);
 
             if (previousTopTracksCall.Success)
             {
@@ -918,8 +910,7 @@ public class TrackBuilders
                 .ToList();
         }
 
-        var trackPages = topTracks.Content.TopTracks
-            .ChunkBy(topListSettings.ExtraLarge ? Constants.DefaultExtraLargePageSize : Constants.DefaultPageSize);
+        var trackPages = topTracks.Content.TopTracks.ChunkBy((int)topListSettings.EmbedSize);
 
         var counter = 1;
         var pageCounter = 1;
@@ -936,8 +927,7 @@ public class TrackBuilders
                 if (!tooMuchChars)
                 {
                     name.Append($"**{StringExtensions.Sanitize(track.ArtistName)}** - **[{track.TrackName}]({track.TrackUrl})** ");
-                }
-                else
+                } else
                 {
                     name.Append($"**{StringExtensions.Sanitize(track.ArtistName)}** - **{track.TrackName}** ");
                 }
@@ -946,8 +936,7 @@ public class TrackBuilders
                 {
                     name.Append(
                         $"- *{track.UserPlaycount} {StringExtensions.GetPlaysString(track.UserPlaycount)}*");
-                }
-                else
+                } else
                 {
                     name.Append(
                         $"- *{StringExtensions.GetListeningTimeString(track.TimeListened.TotalTimeListened)}*");
@@ -959,8 +948,7 @@ public class TrackBuilders
                     int? previousPosition = previousTopTrack == null ? null : previousTopTracks.IndexOf(previousTopTrack);
 
                     trackPageString.AppendLine(StringService.GetBillboardLine(name.ToString(), counter - 1, previousPosition).Text);
-                }
-                else
+                } else
                 {
                     trackPageString.Append($"{counter}. ");
                     trackPageString.AppendLine(name.ToString());
@@ -1053,7 +1041,4 @@ public class TrackBuilders
 
         return response;
     }
-
-
 }
-

--- a/src/FMBot.Bot/Models/TasteModels.cs
+++ b/src/FMBot.Bot/Models/TasteModels.cs
@@ -8,7 +8,7 @@ public class TasteSettings
 {
     public TasteType TasteType { get; set; }
 
-    public EmbedSize EmbedSize { get; set; }
+    public EmbedSize EmbedSize { get; set; } = EmbedSize.Default;
 }
 
 public class TasteModels

--- a/src/FMBot.Bot/Models/TasteModels.cs
+++ b/src/FMBot.Bot/Models/TasteModels.cs
@@ -1,4 +1,5 @@
 using Discord;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Models;
 
 namespace FMBot.Bot.Models;
@@ -7,7 +8,7 @@ public class TasteSettings
 {
     public TasteType TasteType { get; set; }
 
-    public bool ExtraLarge { get; set; }
+    public EmbedSize EmbedSize { get; set; }
 }
 
 public class TasteModels

--- a/src/FMBot.Bot/Models/TopListModel.cs
+++ b/src/FMBot.Bot/Models/TopListModel.cs
@@ -1,31 +1,29 @@
+using FMBot.Domain.Enums;
+
 namespace FMBot.Bot.Models;
 
 public class TopListSettings
 {
-    public TopListSettings()
+    public TopListSettings() { }
+
+    public TopListSettings(EmbedSize embedSize)
     {
+        this.EmbedSize = embedSize;
     }
 
-    public TopListSettings(bool extraLarge)
+    public TopListSettings(EmbedSize embedSize, bool billboard, bool discogs = false)
     {
-        this.ExtraLarge = extraLarge;
-    }
-
-    public TopListSettings(bool extraLarge, bool billboard, bool discogs = false)
-    {
-        this.ExtraLarge = extraLarge;
+        this.EmbedSize = embedSize;
         this.Billboard = billboard;
         this.Discogs = discogs;
     }
 
-    public bool ExtraLarge { get; set; }
-
+    public EmbedSize EmbedSize { get; set; }
     public bool Billboard { get; set; }
     public bool Discogs { get; set; }
     public string NewSearchValue { get; set; }
 
     public TopListType Type { get; set; }
-
 }
 
 public enum TopListType

--- a/src/FMBot.Bot/Models/TopListModel.cs
+++ b/src/FMBot.Bot/Models/TopListModel.cs
@@ -4,7 +4,10 @@ namespace FMBot.Bot.Models;
 
 public class TopListSettings
 {
-    public TopListSettings() { }
+    public TopListSettings()
+    {
+        EmbedSize = EmbedSize.Default;
+    }
 
     public TopListSettings(EmbedSize embedSize)
     {

--- a/src/FMBot.Bot/Services/ArtistsService.cs
+++ b/src/FMBot.Bot/Services/ArtistsService.cs
@@ -97,8 +97,7 @@ public class ArtistsService
             if (useCachedArtists)
             {
                 artistCall = await GetCachedArtist(artistValues, lastFmUserName, userId, redirectsEnabled);
-            }
-            else
+            } else
             {
                 artistCall = await this._dataSourceFactory.GetArtistInfoAsync(artistValues, lastFmUserName, redirectsEnabled);
             }
@@ -119,16 +118,14 @@ public class ArtistsService
             }
 
             return new ArtistSearch(artistCall.Content, response, rndPosition, rndPlaycount);
-        }
-        else
+        } else
         {
             Response<RecentTrackList> recentScrobbles;
 
             if (userId.HasValue && otherUserUsername == null)
             {
                 recentScrobbles = await this._updateService.UpdateUser(new UpdateUserQueueItem(userId.Value, getAccurateTotalPlaycount: false));
-            }
-            else
+            } else
             {
                 recentScrobbles = await this._dataSourceFactory.GetRecentTracksAsync(lastFmUserName, 1, true, sessionKey);
             }
@@ -149,8 +146,7 @@ public class ArtistsService
             if (useCachedArtists)
             {
                 artistCall = await GetCachedArtist(lastPlayedTrack.ArtistName, lastFmUserName, userId, redirectsEnabled);
-            }
-            else
+            } else
             {
                 artistCall = await this._dataSourceFactory.GetArtistInfoAsync(lastPlayedTrack.ArtistName, lastFmUserName, redirectsEnabled);
             }
@@ -175,8 +171,7 @@ public class ArtistsService
         {
             artistInfo = new Response<ArtistInfo>
             {
-                Content = CachedArtistToArtistInfo(cachedArtist),
-                Success = true
+                Content = CachedArtistToArtistInfo(cachedArtist), Success = true
             };
 
             if (userId.HasValue)
@@ -184,8 +179,7 @@ public class ArtistsService
                 var userPlaycount = await this._whoKnowsArtistService.GetArtistPlayCountForUser(cachedArtist.Name, userId.Value);
                 artistInfo.Content.UserPlaycount = userPlaycount;
             }
-        }
-        else
+        } else
         {
             artistInfo = await this._dataSourceFactory.GetArtistInfoAsync(artistName, lastFmUserName, redirectsEnabled);
         }
@@ -197,9 +191,7 @@ public class ArtistsService
     {
         return new ArtistInfo
         {
-            ArtistName = artist.Name,
-            ArtistUrl = artist.LastFmUrl,
-            Mbid = artist.Mbid
+            ArtistName = artist.Name, ArtistUrl = artist.LastFmUrl, Mbid = artist.Mbid
         };
     }
 
@@ -271,8 +263,7 @@ public class ArtistsService
             if (!string.IsNullOrWhiteSpace(name) && name.Length > 24)
             {
                 left += $"**{name.Substring(0, 24)}..**\n";
-            }
-            else
+            } else
             {
                 left += $"**{name}**\n";
             }
@@ -283,8 +274,7 @@ public class ArtistsService
             if (ownPlaycount > otherPlaycount)
             {
                 right += $"**{ownPlaycount}**";
-            }
-            else
+            } else
             {
                 right += $"{ownPlaycount}";
             }
@@ -294,8 +284,7 @@ public class ArtistsService
             if (otherPlaycount > ownPlaycount)
             {
                 right += $"**{otherPlaycount}**";
-            }
-            else
+            } else
             {
                 right += $"{otherPlaycount}";
             }
@@ -306,9 +295,7 @@ public class ArtistsService
 
         return new TasteModels
         {
-            Description = description,
-            LeftDescription = left,
-            RightDescription = right
+            Description = description, LeftDescription = left, RightDescription = right
         };
     }
 
@@ -326,8 +313,7 @@ public class ArtistsService
         var freshTopArtists = (await ArtistRepository.GetUserArtists(userId, connection))
             .Select(s => new TopArtist
             {
-                ArtistName = s.Name,
-                UserPlaycount = s.Playcount
+                ArtistName = s.Name, UserPlaycount = s.Playcount
             })
             .OrderByDescending(o => o.UserPlaycount)
             .ToList();
@@ -383,7 +369,10 @@ public class ArtistsService
         {
             var customTable = artists
                 .Take(amount)
-                .ToTasteTable(new[] { type, mainUser, "   ", userToCompare },
+                .ToTasteTable(new[]
+                    {
+                        type, mainUser, "   ", userToCompare
+                    },
                     u => u.Artist,
                     u => u.OwnPlaycount,
                     u => GetCompareChar(u.OwnPlaycount, u.OtherPlaycount),
@@ -391,8 +380,7 @@ public class ArtistsService
                 );
 
             description.Append($"```{customTable}```");
-        }
-        else
+        } else
         {
             description.AppendLine();
             description.AppendLine($"No {type.ToLower()} matches... <:404:882220605783560222>");
@@ -408,8 +396,7 @@ public class ArtistsService
         if (!mainUserArtists.Any() || !matchedArtists.Any())
         {
             percentage = 0;
-        }
-        else
+        } else
         {
             percentage = ((decimal)matchedArtists.Count / (decimal)mainUserArtists.Count()) * 100;
         }
@@ -454,7 +441,10 @@ public class ArtistsService
         }
         if (extraOptions.Contains("xl") || extraOptions.Contains("xxl") || extraOptions.Contains("extralarge"))
         {
-            tasteSettings.ExtraLarge = true;
+            tasteSettings.EmbedSize = EmbedSize.Large;
+        } else if (extraOptions.Contains("xs") || extraOptions.Contains("xxs") || extraOptions.Contains("extrasmall"))
+        {
+            tasteSettings.EmbedSize = EmbedSize.Small;
         }
 
         return tasteSettings;
@@ -532,7 +522,10 @@ public class ArtistsService
 
             if (user == null)
             {
-                return new List<string> { Constants.AutoCompleteLoginRequired };
+                return new List<string>
+                {
+                    Constants.AutoCompleteLoginRequired
+                };
             }
 
             await using var connection = new NpgsqlConnection(this._botSettings.Database.ConnectionString);
@@ -549,8 +542,7 @@ public class ArtistsService
             this._cache.Set(cacheKey, artists, TimeSpan.FromSeconds(30));
 
             return artists;
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             Log.Error("Error in GetLatestArtists", e);
             throw;
@@ -574,7 +566,10 @@ public class ArtistsService
 
             if (user == null)
             {
-                return new List<string> { Constants.AutoCompleteLoginRequired };
+                return new List<string>
+                {
+                    Constants.AutoCompleteLoginRequired
+                };
             }
 
             await using var connection = new NpgsqlConnection(this._botSettings.Database.ConnectionString);
@@ -591,8 +586,7 @@ public class ArtistsService
             this._cache.Set(cacheKey, artists, TimeSpan.FromSeconds(120));
 
             return artists;
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             Log.Error("Error in GetRecentTopArtists", e);
             throw;
@@ -631,8 +625,7 @@ public class ArtistsService
                 .OrderByDescending(o => o.Popularity));
 
             return results;
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             Log.Error("Error in SearchThroughArtists", e);
             throw;

--- a/src/FMBot.Bot/Services/ArtistsService.cs
+++ b/src/FMBot.Bot/Services/ArtistsService.cs
@@ -97,7 +97,8 @@ public class ArtistsService
             if (useCachedArtists)
             {
                 artistCall = await GetCachedArtist(artistValues, lastFmUserName, userId, redirectsEnabled);
-            } else
+            }
+            else
             {
                 artistCall = await this._dataSourceFactory.GetArtistInfoAsync(artistValues, lastFmUserName, redirectsEnabled);
             }
@@ -118,14 +119,16 @@ public class ArtistsService
             }
 
             return new ArtistSearch(artistCall.Content, response, rndPosition, rndPlaycount);
-        } else
+        }
+        else
         {
             Response<RecentTrackList> recentScrobbles;
 
             if (userId.HasValue && otherUserUsername == null)
             {
                 recentScrobbles = await this._updateService.UpdateUser(new UpdateUserQueueItem(userId.Value, getAccurateTotalPlaycount: false));
-            } else
+            }
+            else
             {
                 recentScrobbles = await this._dataSourceFactory.GetRecentTracksAsync(lastFmUserName, 1, true, sessionKey);
             }
@@ -146,7 +149,8 @@ public class ArtistsService
             if (useCachedArtists)
             {
                 artistCall = await GetCachedArtist(lastPlayedTrack.ArtistName, lastFmUserName, userId, redirectsEnabled);
-            } else
+            }
+            else
             {
                 artistCall = await this._dataSourceFactory.GetArtistInfoAsync(lastPlayedTrack.ArtistName, lastFmUserName, redirectsEnabled);
             }
@@ -171,7 +175,8 @@ public class ArtistsService
         {
             artistInfo = new Response<ArtistInfo>
             {
-                Content = CachedArtistToArtistInfo(cachedArtist), Success = true
+                Content = CachedArtistToArtistInfo(cachedArtist),
+                Success = true
             };
 
             if (userId.HasValue)
@@ -179,7 +184,8 @@ public class ArtistsService
                 var userPlaycount = await this._whoKnowsArtistService.GetArtistPlayCountForUser(cachedArtist.Name, userId.Value);
                 artistInfo.Content.UserPlaycount = userPlaycount;
             }
-        } else
+        }
+        else
         {
             artistInfo = await this._dataSourceFactory.GetArtistInfoAsync(artistName, lastFmUserName, redirectsEnabled);
         }
@@ -191,7 +197,9 @@ public class ArtistsService
     {
         return new ArtistInfo
         {
-            ArtistName = artist.Name, ArtistUrl = artist.LastFmUrl, Mbid = artist.Mbid
+            ArtistName = artist.Name,
+            ArtistUrl = artist.LastFmUrl,
+            Mbid = artist.Mbid
         };
     }
 
@@ -263,7 +271,8 @@ public class ArtistsService
             if (!string.IsNullOrWhiteSpace(name) && name.Length > 24)
             {
                 left += $"**{name.Substring(0, 24)}..**\n";
-            } else
+            }
+            else
             {
                 left += $"**{name}**\n";
             }
@@ -274,7 +283,8 @@ public class ArtistsService
             if (ownPlaycount > otherPlaycount)
             {
                 right += $"**{ownPlaycount}**";
-            } else
+            }
+            else
             {
                 right += $"{ownPlaycount}";
             }
@@ -284,7 +294,8 @@ public class ArtistsService
             if (otherPlaycount > ownPlaycount)
             {
                 right += $"**{otherPlaycount}**";
-            } else
+            }
+            else
             {
                 right += $"{otherPlaycount}";
             }
@@ -295,7 +306,9 @@ public class ArtistsService
 
         return new TasteModels
         {
-            Description = description, LeftDescription = left, RightDescription = right
+            Description = description,
+            LeftDescription = left,
+            RightDescription = right
         };
     }
 
@@ -313,7 +326,8 @@ public class ArtistsService
         var freshTopArtists = (await ArtistRepository.GetUserArtists(userId, connection))
             .Select(s => new TopArtist
             {
-                ArtistName = s.Name, UserPlaycount = s.Playcount
+                ArtistName = s.Name,
+                UserPlaycount = s.Playcount
             })
             .OrderByDescending(o => o.UserPlaycount)
             .ToList();
@@ -369,10 +383,7 @@ public class ArtistsService
         {
             var customTable = artists
                 .Take(amount)
-                .ToTasteTable(new[]
-                    {
-                        type, mainUser, "   ", userToCompare
-                    },
+                .ToTasteTable(new[] { type, mainUser, "   ", userToCompare },
                     u => u.Artist,
                     u => u.OwnPlaycount,
                     u => GetCompareChar(u.OwnPlaycount, u.OtherPlaycount),
@@ -380,7 +391,8 @@ public class ArtistsService
                 );
 
             description.Append($"```{customTable}```");
-        } else
+        }
+        else
         {
             description.AppendLine();
             description.AppendLine($"No {type.ToLower()} matches... <:404:882220605783560222>");
@@ -396,7 +408,8 @@ public class ArtistsService
         if (!mainUserArtists.Any() || !matchedArtists.Any())
         {
             percentage = 0;
-        } else
+        }
+        else
         {
             percentage = ((decimal)matchedArtists.Count / (decimal)mainUserArtists.Count()) * 100;
         }
@@ -442,7 +455,8 @@ public class ArtistsService
         if (extraOptions.Contains("xl") || extraOptions.Contains("xxl") || extraOptions.Contains("extralarge"))
         {
             tasteSettings.EmbedSize = EmbedSize.Large;
-        } else if (extraOptions.Contains("xs") || extraOptions.Contains("xxs") || extraOptions.Contains("extrasmall"))
+        }
+        else if (extraOptions.Contains("xs") || extraOptions.Contains("xxs") || extraOptions.Contains("extrasmall"))
         {
             tasteSettings.EmbedSize = EmbedSize.Small;
         }
@@ -522,10 +536,7 @@ public class ArtistsService
 
             if (user == null)
             {
-                return new List<string>
-                {
-                    Constants.AutoCompleteLoginRequired
-                };
+                return new List<string> { Constants.AutoCompleteLoginRequired };
             }
 
             await using var connection = new NpgsqlConnection(this._botSettings.Database.ConnectionString);
@@ -542,7 +553,8 @@ public class ArtistsService
             this._cache.Set(cacheKey, artists, TimeSpan.FromSeconds(30));
 
             return artists;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             Log.Error("Error in GetLatestArtists", e);
             throw;
@@ -566,10 +578,7 @@ public class ArtistsService
 
             if (user == null)
             {
-                return new List<string>
-                {
-                    Constants.AutoCompleteLoginRequired
-                };
+                return new List<string> { Constants.AutoCompleteLoginRequired };
             }
 
             await using var connection = new NpgsqlConnection(this._botSettings.Database.ConnectionString);
@@ -586,7 +595,8 @@ public class ArtistsService
             this._cache.Set(cacheKey, artists, TimeSpan.FromSeconds(120));
 
             return artists;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             Log.Error("Error in GetRecentTopArtists", e);
             throw;
@@ -625,7 +635,8 @@ public class ArtistsService
                 .OrderByDescending(o => o.Popularity));
 
             return results;
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             Log.Error("Error in SearchThroughArtists", e);
             throw;

--- a/src/FMBot.Bot/Services/SettingService.cs
+++ b/src/FMBot.Bot/Services/SettingService.cs
@@ -393,7 +393,7 @@ public class SettingService
         var topListSettings = new TopListSettings
         {
             Billboard = false,
-            ExtraLarge = false,
+            EmbedSize = EmbedSize.Default,
             Discogs = false,
             NewSearchValue = extraOptions
         };
@@ -411,11 +411,18 @@ public class SettingService
         }
 
         var extraLarge = new[] { "xl", "xxl", "extralarge" };
+        var extraSmall = new[] { "xs", "xxs", "extrasmall" };
         if (Contains(extraOptions, extraLarge))
         {
             topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, extraLarge);
-            topListSettings.ExtraLarge = true;
+            topListSettings.EmbedSize = EmbedSize.Large;
+        } else if (Contains(extraOptions, extraSmall))
+        {
+            topListSettings.NewSearchValue = ContainsAndRemove(topListSettings.NewSearchValue, extraSmall);
+            topListSettings.EmbedSize = EmbedSize.Small;
         }
+
+
         var discogs = new[] { "dc", "discogs" };
         if (Contains(extraOptions, discogs))
         {

--- a/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
@@ -268,7 +268,8 @@ public class ArtistSlashCommands : InteractionModuleBase
     public async Task ArtistDiscoveriesAsync(
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more discoveries")] bool extraLarge = false,
+        [Summary("XXS", "Show less discoveries")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -288,6 +289,9 @@ public class ArtistSlashCommands : InteractionModuleBase
         _ = DeferAsync(privateResponse);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.Quarterly);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize);
 
@@ -311,7 +315,8 @@ public class ArtistSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Type", "Taste view type")] TasteType tasteType = TasteType.Table,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
-        [Summary("XXL/XXS", "Show extra large/small comparison")] EmbedSize embedSize = EmbedSize.Default)
+        [Summary("XXL", "Show more taste comparisons")] bool extraLarge = false,
+        [Summary("XXS", "Show less taste comparisons")] bool extraSmall = false)
     {
         _ = DeferAsync(privateResponse);
 
@@ -321,6 +326,9 @@ public class ArtistSlashCommands : InteractionModuleBase
         try
         {
             var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.AllTime);
+
+            var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+            embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
             var response = await this._artistBuilders.TasteAsync(new ContextModel(this.Context, contextUser),
                 new TasteSettings { TasteType = tasteType, EmbedSize = embedSize }, timeSettings, userSettings);

--- a/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
@@ -13,6 +13,7 @@ using FMBot.Bot.Models;
 using FMBot.Bot.Resources;
 using FMBot.Bot.Services;
 using FMBot.Bot.Services.Guild;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Interfaces;
 using FMBot.Domain.Models;
 using FMBot.LastFM.Repositories;
@@ -267,7 +268,7 @@ public class ArtistSlashCommands : InteractionModuleBase
     public async Task ArtistDiscoveriesAsync(
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top artists")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -288,7 +289,7 @@ public class ArtistSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.Quarterly);
 
-        var topListSettings = new TopListSettings(extraLarge);
+        var topListSettings = new TopListSettings(embedSize);
 
         var response = await this._artistBuilders.ArtistDiscoveriesAsync(context, topListSettings, timeSettings, userSettings);
 
@@ -310,7 +311,7 @@ public class ArtistSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Type", "Taste view type")] TasteType tasteType = TasteType.Table,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
-        [Summary("XXL", "Show extra large comparison")] bool extraLarge = false)
+        [Summary("XXL/XXS", "Show extra large/small comparison")] EmbedSize embedSize = EmbedSize.Default)
     {
         _ = DeferAsync(privateResponse);
 
@@ -322,7 +323,7 @@ public class ArtistSlashCommands : InteractionModuleBase
             var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.AllTime);
 
             var response = await this._artistBuilders.TasteAsync(new ContextModel(this.Context, contextUser),
-                new TasteSettings { TasteType = tasteType, ExtraLarge = extraLarge }, timeSettings, userSettings);
+                new TasteSettings { TasteType = tasteType, EmbedSize = embedSize }, timeSettings, userSettings);
 
             await this.Context.SendFollowUpResponse(this.Interactivity, response, privateResponse);
             this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/ArtistSlashCommands.cs
@@ -268,8 +268,7 @@ public class ArtistSlashCommands : InteractionModuleBase
     public async Task ArtistDiscoveriesAsync(
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more discoveries")] bool extraLarge = false,
-        [Summary("XXS", "Show less discoveries")] bool extraSmall = false,
+        [Summary("Size", "Amount of artists discoveries to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -290,10 +289,7 @@ public class ArtistSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.Quarterly);
 
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default);
 
         var response = await this._artistBuilders.ArtistDiscoveriesAsync(context, topListSettings, timeSettings, userSettings);
 
@@ -315,8 +311,7 @@ public class ArtistSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Type", "Taste view type")] TasteType tasteType = TasteType.Table,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
-        [Summary("XXL", "Show more taste comparisons")] bool extraLarge = false,
-        [Summary("XXS", "Show less taste comparisons")] bool extraSmall = false)
+        [Summary("Size", "Amount of comparisons to show")] EmbedSize? embedSize = null)
     {
         _ = DeferAsync(privateResponse);
 
@@ -327,11 +322,8 @@ public class ArtistSlashCommands : InteractionModuleBase
         {
             var timeSettings = SettingService.GetTimePeriod(timePeriod, TimePeriod.AllTime);
 
-            var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-            embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
             var response = await this._artistBuilders.TasteAsync(new ContextModel(this.Context, contextUser),
-                new TasteSettings { TasteType = tasteType, EmbedSize = embedSize }, timeSettings, userSettings);
+                new TasteSettings { TasteType = tasteType, EmbedSize = embedSize ?? EmbedSize.Default }, timeSettings, userSettings);
 
             await this.Context.SendFollowUpResponse(this.Interactivity, response, privateResponse);
             this.Context.LogCommandUsed(response.CommandResponse);

--- a/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
@@ -54,8 +54,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top artists billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more top artists")] bool extraLarge = false,
-        [Summary("XXS", "Show less top artists")] bool extraSmall = false,
+        [Summary("Size", "Amount of artists to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
         [Summary("Discogs", "Show top artists in Discogs collection")] bool discogs = false)
     {
@@ -63,11 +62,7 @@ public class TopSlashCommands : InteractionModuleBase
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, discogs ? TimePeriod.AllTime : TimePeriod.Weekly, discogs ? DateTime.MinValue : null);
-
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize, billboard, discogs);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default, billboard, discogs);
 
         var response = topListSettings.Discogs
             ? await this._discogsBuilders.DiscogsTopArtistsAsync(new ContextModel(this.Context, contextUser),
@@ -85,8 +80,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top albums billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more top albums")] bool extraLarge = false,
-        [Summary("XXS", "Show less top albums")] bool extraSmall = false,
+        [Summary("Size", "Amount of albums to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -94,10 +88,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize, billboard);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default, billboard);
 
         var response = await this._albumBuilders.TopAlbumsAsync(new ContextModel(this.Context, contextUser), topListSettings, timeSettings, userSettings);
 
@@ -111,8 +102,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top tracks billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more top tracks")] bool extraLarge = false,
-        [Summary("XXS", "Show less top tracks")] bool extraSmall = false,
+        [Summary("Size", "Amount of tracks to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -120,10 +110,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize, billboard);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default, billboard);
 
         var response = await this._trackBuilders.TopTracksAsync(new ContextModel(this.Context, contextUser), topListSettings, timeSettings, userSettings);
 
@@ -137,8 +124,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top genres billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more top genres")] bool extraLarge = false,
-        [Summary("XXS", "Show less top genres")] bool extraSmall = false,
+        [Summary("Size", "Amount of genres to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -146,10 +132,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize, billboard);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default, billboard);
 
         var response = await this._genreBuilders.GetTopGenres(new ContextModel(this.Context, contextUser), userSettings, timeSettings, topListSettings);
 
@@ -163,8 +146,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top countries billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show more top countries")] bool extraLarge = false,
-        [Summary("XXS", "Show less top countries")] bool extraSmall = false,
+        [Summary("Size", "Amount of countries to show")] EmbedSize? embedSize = null,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -172,10 +154,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
-        embedSize = extraLarge ? EmbedSize.Large : embedSize;
-
-        var topListSettings = new TopListSettings(embedSize, billboard);
+        var topListSettings = new TopListSettings(embedSize ?? EmbedSize.Default, billboard);
 
         var response = await this._countryBuilders.GetTopCountries(new ContextModel(this.Context, contextUser), userSettings, timeSettings, topListSettings);
 

--- a/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
@@ -54,7 +54,8 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top artists billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more top artists")] bool extraLarge = false,
+        [Summary("XXS", "Show less top artists")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
         [Summary("Discogs", "Show top artists in Discogs collection")] bool discogs = false)
     {
@@ -62,6 +63,9 @@ public class TopSlashCommands : InteractionModuleBase
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, discogs ? TimePeriod.AllTime : TimePeriod.Weekly, discogs ? DateTime.MinValue : null);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize, billboard, discogs);
 
@@ -81,13 +85,17 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top albums billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more top albums")] bool extraLarge = false,
+        [Summary("XXS", "Show less top albums")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize, billboard);
 
@@ -103,13 +111,17 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top tracks billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more top tracks")] bool extraLarge = false,
+        [Summary("XXS", "Show less top tracks")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize, billboard);
 
@@ -125,13 +137,17 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top genres billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more top genres")] bool extraLarge = false,
+        [Summary("XXS", "Show less top genres")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize, billboard);
 
@@ -147,13 +163,17 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top countries billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
+        [Summary("XXL", "Show more top countries")] bool extraLarge = false,
+        [Summary("XXS", "Show less top countries")] bool extraSmall = false,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
         var userSettings = await this._settingService.GetUser(user, contextUser, this.Context.Guild, this.Context.User, true);
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
+
+        var embedSize = extraSmall ? EmbedSize.Small : EmbedSize.Default;
+        embedSize = extraLarge ? EmbedSize.Large : embedSize;
 
         var topListSettings = new TopListSettings(embedSize, billboard);
 

--- a/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/TopSlashCommands.cs
@@ -8,6 +8,7 @@ using FMBot.Bot.Builders;
 using FMBot.Bot.Extensions;
 using FMBot.Bot.Models;
 using FMBot.Bot.Services;
+using FMBot.Domain.Enums;
 using FMBot.Domain.Models;
 
 namespace FMBot.Bot.SlashCommands;
@@ -53,7 +54,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top artists billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top artists")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false,
         [Summary("Discogs", "Show top artists in Discogs collection")] bool discogs = false)
     {
@@ -62,7 +63,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod, discogs ? TimePeriod.AllTime : TimePeriod.Weekly, discogs ? DateTime.MinValue : null);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard, discogs);
+        var topListSettings = new TopListSettings(embedSize, billboard, discogs);
 
         var response = topListSettings.Discogs
             ? await this._discogsBuilders.DiscogsTopArtistsAsync(new ContextModel(this.Context, contextUser),
@@ -80,7 +81,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top albums billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top albums")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -88,7 +89,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard);
+        var topListSettings = new TopListSettings(embedSize, billboard);
 
         var response = await this._albumBuilders.TopAlbumsAsync(new ContextModel(this.Context, contextUser), topListSettings, timeSettings, userSettings);
 
@@ -102,7 +103,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top tracks billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top tracks")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -110,7 +111,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard);
+        var topListSettings = new TopListSettings(embedSize, billboard);
 
         var response = await this._trackBuilders.TopTracksAsync(new ContextModel(this.Context, contextUser), topListSettings, timeSettings, userSettings);
 
@@ -124,7 +125,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top genres billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top genres")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -132,7 +133,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard);
+        var topListSettings = new TopListSettings(embedSize, billboard);
 
         var response = await this._genreBuilders.GetTopGenres(new ContextModel(this.Context, contextUser), userSettings, timeSettings, topListSettings);
 
@@ -146,7 +147,7 @@ public class TopSlashCommands : InteractionModuleBase
         [Summary("Time-period", "Time period")][Autocomplete(typeof(DateTimeAutoComplete))] string timePeriod = null,
         [Summary("Billboard", "Show top countries billboard-style")] bool billboard = false,
         [Summary("User", "The user to show (defaults to self)")] string user = null,
-        [Summary("XXL", "Show extra top countries")] bool extraLarge = false,
+        [Summary("XXL/XXS", "Show extra/less top artists")] EmbedSize embedSize = EmbedSize.Default,
         [Summary("Private", "Only show response to you")] bool privateResponse = false)
     {
         var contextUser = await this._userService.GetUserSettingsAsync(this.Context.User);
@@ -154,7 +155,7 @@ public class TopSlashCommands : InteractionModuleBase
 
         var timeSettings = SettingService.GetTimePeriod(timePeriod);
 
-        var topListSettings = new TopListSettings(extraLarge, billboard);
+        var topListSettings = new TopListSettings(embedSize, billboard);
 
         var response = await this._countryBuilders.GetTopCountries(new ContextModel(this.Context, contextUser), userSettings, timeSettings, topListSettings);
 

--- a/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
@@ -183,7 +183,7 @@ public class AlbumCommands : BaseCommandModule
     [Command("topalbums", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top albums over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
+        Constants.BillboardExample, Constants.EmbedSizeExample)]
     [Examples("tab", "topalbums", "tab a lfm:fm-bot", "topalbums weekly @user", "tab bb xl")]
     [Alias("abl", "abs", "tab", "albumlist", "top albums", "albums", "albumslist")]
     [UsernameSetRequired]

--- a/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/AlbumCommands.cs
@@ -183,7 +183,7 @@ public class AlbumCommands : BaseCommandModule
     [Command("topalbums", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top albums over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample)]
+        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
     [Examples("tab", "topalbums", "tab a lfm:fm-bot", "topalbums weekly @user", "tab bb xl")]
     [Alias("abl", "abs", "tab", "albumlist", "top albums", "albums", "albumslist")]
     [UsernameSetRequired]

--- a/src/FMBot.Bot/TextCommands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/ArtistCommands.cs
@@ -99,8 +99,7 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -208,8 +207,7 @@ public class ArtistCommands : BaseCommandModule
                 footer.AppendLine($" - {userSettings.UserNameLastFm} has {artist.Artist.UserPlaycount} total scrobbles on this artist");
                 footer.AppendLine($"Requested by {userTitle}");
                 title.Append($"{userSettings.DisplayName}'s top albums for '{artist.Artist.ArtistName}'");
-            }
-            else
+            } else
             {
                 footer.Append($" - {userTitle} has {artist.Artist.UserPlaycount} total scrobbles on this artist");
                 title.Append($"Your top albums for '{artist.Artist.ArtistName}'");
@@ -316,8 +314,7 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -326,7 +323,7 @@ public class ArtistCommands : BaseCommandModule
     [Command("topartists", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top artists over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample)]
+        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
     [Examples("ta", "topartists", "ta a lfm:fm-bot", "topartists weekly @user", "ta bb xl")]
     [Alias("al", "as", "ta", "artistlist", "artists", "top artists", "artistslist")]
     [UsernameSetRequired]
@@ -365,8 +362,7 @@ public class ArtistCommands : BaseCommandModule
             //{
             //    await this._smallIndexRepository.UpdateUserArtists(contextUser, artists.Content.TopArtists);
             //}
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -374,7 +370,7 @@ public class ArtistCommands : BaseCommandModule
 
     [Command("discoveries", RunMode = RunMode.Async)]
     [Summary("Shows the artists you've recently discovered.")]
-    [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample, Constants.ExtraLargeExample)]
+    [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
     [Examples("d", "discovered", "ta a lfm:fm-bot", "topartists weekly @user", "ta bb xl")]
     [Alias("d", "discovered", "discovery", "artistdiscoveries", "firstlistened")]
     [UsernameSetRequired]
@@ -410,8 +406,7 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -419,7 +414,7 @@ public class ArtistCommands : BaseCommandModule
 
     [Command("taste", RunMode = RunMode.Async)]
     [Summary("Compares your top artists, genres and countries to those from another user.")]
-    [Options(Constants.CompactTimePeriodList, Constants.UserMentionOrLfmUserNameExample, "Mode: `table` or `embed`", "XXL")]
+    [Options(Constants.CompactTimePeriodList, Constants.UserMentionOrLfmUserNameExample, "Mode: `table` or `embed`", "XXL", "XXS")]
     [Examples("t frikandel_", "t @user", "taste bitldev", "taste @user monthly embed")]
     [UsernameSetRequired]
     [Alias("t")]
@@ -439,7 +434,7 @@ public class ArtistCommands : BaseCommandModule
 
         var tasteSettings = new TasteSettings
         {
-            ExtraLarge = false
+            EmbedSize = EmbedSize.Default
         };
 
         tasteSettings = this._artistsService.SetTasteSettings(tasteSettings, timeSettings.NewSearchValue);
@@ -451,8 +446,7 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -477,9 +471,7 @@ public class ArtistCommands : BaseCommandModule
 
             var currentSettings = new WhoKnowsSettings
             {
-                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed,
-                NewSearchValue = artistValues,
-                DisplayRoleFilter = false
+                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed, NewSearchValue = artistValues, DisplayRoleFilter = false
             };
 
             var settings = this._settingService.SetWhoKnowsSettings(currentSettings, artistValues, contextUser.UserType);
@@ -494,16 +486,14 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            }
-            else
+            } else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -541,16 +531,14 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            }
-            else
+            } else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -575,8 +563,7 @@ public class ArtistCommands : BaseCommandModule
         {
             var currentSettings = new WhoKnowsSettings
             {
-                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed,
-                NewSearchValue = artistValues
+                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed, NewSearchValue = artistValues
             };
 
             var settings = this._settingService.SetWhoKnowsSettings(currentSettings, artistValues, contextUser.UserType);
@@ -587,16 +574,14 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            }
-            else
+            } else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -645,8 +630,7 @@ public class ArtistCommands : BaseCommandModule
                 TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds));
 
             this.Context.LogCommandUsed(response.CommandResponse);
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -701,8 +685,7 @@ public class ArtistCommands : BaseCommandModule
                     response.StaticPaginator,
                     message,
                     TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds));
-            }
-            else
+            } else
             {
                 response = await this._artistBuilders
                     .AffinityAsync(new ContextModel(this.Context, prfx, contextUser), userSettings, guild, guildUsers, largeGuild);
@@ -712,8 +695,7 @@ public class ArtistCommands : BaseCommandModule
 
             this.Context.LogCommandUsed(response.CommandResponse);
 
-        }
-        catch (Exception e)
+        } catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -745,16 +727,14 @@ public class ArtistCommands : BaseCommandModule
             }
 
             return artistCall.Content;
-        }
-        else
+        } else
         {
             Response<RecentTrackList> recentScrobbles;
 
             if (user != null)
             {
                 recentScrobbles = await this._updateService.UpdateUserAndGetRecentTracks(user);
-            }
-            else
+            } else
             {
                 recentScrobbles = await this._dataSourceFactory.GetRecentTracksAsync(lastFmUserName, 1, true, sessionKey);
             }

--- a/src/FMBot.Bot/TextCommands/LastFM/ArtistCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/ArtistCommands.cs
@@ -99,7 +99,8 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -207,7 +208,8 @@ public class ArtistCommands : BaseCommandModule
                 footer.AppendLine($" - {userSettings.UserNameLastFm} has {artist.Artist.UserPlaycount} total scrobbles on this artist");
                 footer.AppendLine($"Requested by {userTitle}");
                 title.Append($"{userSettings.DisplayName}'s top albums for '{artist.Artist.ArtistName}'");
-            } else
+            }
+            else
             {
                 footer.Append($" - {userTitle} has {artist.Artist.UserPlaycount} total scrobbles on this artist");
                 title.Append($"Your top albums for '{artist.Artist.ArtistName}'");
@@ -314,7 +316,8 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -323,7 +326,7 @@ public class ArtistCommands : BaseCommandModule
     [Command("topartists", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top artists over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
+        Constants.BillboardExample, Constants.EmbedSizeExample)]
     [Examples("ta", "topartists", "ta a lfm:fm-bot", "topartists weekly @user", "ta bb xl")]
     [Alias("al", "as", "ta", "artistlist", "artists", "top artists", "artistslist")]
     [UsernameSetRequired]
@@ -362,7 +365,8 @@ public class ArtistCommands : BaseCommandModule
             //{
             //    await this._smallIndexRepository.UpdateUserArtists(contextUser, artists.Content.TopArtists);
             //}
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -370,7 +374,7 @@ public class ArtistCommands : BaseCommandModule
 
     [Command("discoveries", RunMode = RunMode.Async)]
     [Summary("Shows the artists you've recently discovered.")]
-    [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
+    [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample, Constants.EmbedSizeExample)]
     [Examples("d", "discovered", "ta a lfm:fm-bot", "topartists weekly @user", "ta bb xl")]
     [Alias("d", "discovered", "discovery", "artistdiscoveries", "firstlistened")]
     [UsernameSetRequired]
@@ -406,7 +410,8 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -414,7 +419,7 @@ public class ArtistCommands : BaseCommandModule
 
     [Command("taste", RunMode = RunMode.Async)]
     [Summary("Compares your top artists, genres and countries to those from another user.")]
-    [Options(Constants.CompactTimePeriodList, Constants.UserMentionOrLfmUserNameExample, "Mode: `table` or `embed`", "XXL", "XXS")]
+    [Options(Constants.CompactTimePeriodList, Constants.UserMentionOrLfmUserNameExample, "Mode: `table` or `embed`", Constants.EmbedSizeExample)]
     [Examples("t frikandel_", "t @user", "taste bitldev", "taste @user monthly embed")]
     [UsernameSetRequired]
     [Alias("t")]
@@ -446,7 +451,8 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -471,7 +477,9 @@ public class ArtistCommands : BaseCommandModule
 
             var currentSettings = new WhoKnowsSettings
             {
-                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed, NewSearchValue = artistValues, DisplayRoleFilter = false
+                WhoKnowsMode = contextUser.Mode ?? WhoKnowsMode.Embed,
+                NewSearchValue = artistValues,
+                DisplayRoleFilter = false
             };
 
             var settings = this._settingService.SetWhoKnowsSettings(currentSettings, artistValues, contextUser.UserType);
@@ -486,14 +494,16 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            } else
+            }
+            else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -531,14 +541,16 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            } else
+            }
+            else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -574,14 +586,16 @@ public class ArtistCommands : BaseCommandModule
 
             await this.Context.SendResponse(this.Interactivity, response);
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             if (!string.IsNullOrEmpty(e.Message) && e.Message.Contains("The server responded with error 50013: Missing Permissions"))
             {
                 await this.Context.HandleCommandException(e, sendReply: false);
                 await ReplyAsync("Error while replying: The bot is missing permissions.\n" +
                                  "Make sure it has permission to 'Embed links' and 'Attach Images'");
-            } else
+            }
+            else
             {
                 await this.Context.HandleCommandException(e);
             }
@@ -630,7 +644,8 @@ public class ArtistCommands : BaseCommandModule
                 TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds));
 
             this.Context.LogCommandUsed(response.CommandResponse);
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -685,7 +700,8 @@ public class ArtistCommands : BaseCommandModule
                     response.StaticPaginator,
                     message,
                     TimeSpan.FromMinutes(DiscordConstants.PaginationTimeoutInSeconds));
-            } else
+            }
+            else
             {
                 response = await this._artistBuilders
                     .AffinityAsync(new ContextModel(this.Context, prfx, contextUser), userSettings, guild, guildUsers, largeGuild);
@@ -695,7 +711,8 @@ public class ArtistCommands : BaseCommandModule
 
             this.Context.LogCommandUsed(response.CommandResponse);
 
-        } catch (Exception e)
+        }
+        catch (Exception e)
         {
             await this.Context.HandleCommandException(e);
         }
@@ -727,14 +744,16 @@ public class ArtistCommands : BaseCommandModule
             }
 
             return artistCall.Content;
-        } else
+        }
+        else
         {
             Response<RecentTrackList> recentScrobbles;
 
             if (user != null)
             {
                 recentScrobbles = await this._updateService.UpdateUserAndGetRecentTracks(user);
-            } else
+            }
+            else
             {
                 recentScrobbles = await this._dataSourceFactory.GetRecentTracksAsync(lastFmUserName, 1, true, sessionKey);
             }

--- a/src/FMBot.Bot/TextCommands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/TrackCommands.cs
@@ -416,7 +416,7 @@ public class TrackCommands : BaseCommandModule
     [Command("toptracks", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top tracks over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample)]
+        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
     [Examples("tt", "toptracks", "tt y 3", "toptracks weekly @user", "tt bb xl")]
     [Alias("tt", "tl", "tracklist", "tracks", "trackslist", "top tracks", "top track")]
     [UsernameSetRequired]

--- a/src/FMBot.Bot/TextCommands/LastFM/TrackCommands.cs
+++ b/src/FMBot.Bot/TextCommands/LastFM/TrackCommands.cs
@@ -416,7 +416,7 @@ public class TrackCommands : BaseCommandModule
     [Command("toptracks", RunMode = RunMode.Async)]
     [Summary("Shows your or someone else's top tracks over a certain time period.")]
     [Options(Constants.CompactTimePeriodList, Constants.UserMentionExample,
-        Constants.BillboardExample, Constants.ExtraLargeExample, Constants.ExtraSmallExample)]
+        Constants.BillboardExample, Constants.EmbedSizeExample)]
     [Examples("tt", "toptracks", "tt y 3", "toptracks weekly @user", "tt bb xl")]
     [Alias("tt", "tl", "tracklist", "tracks", "trackslist", "top tracks", "top track")]
     [UsernameSetRequired]

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -45,7 +45,7 @@ public static class Constants
     public const int DefaultPlaysForCrown = 30;
 
     public const int DefaultPageSize = 10;
-    public const int DefaultExtraSmallPageSize = 6;
+    public const int DefaultExtraSmallPageSize = 5;
     public const int DefaultExtraLargePageSize = 16;
 
     public const int FeaturedMinute = 0;

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -25,6 +25,7 @@ public static class Constants
 
     public const string BillboardExample = "`billboard` / `bb`";
     public const string ExtraLargeExample = "`extralarge` / `xl`";
+    public const string ExtraSmallExample = "`extrasmall` / `xs`";
 
     public const string UserMentionOrLfmUserNameExample = "`fm-bot` / `@usermention` / `356268235697553409`";
 
@@ -44,6 +45,7 @@ public static class Constants
     public const int DefaultPlaysForCrown = 30;
 
     public const int DefaultPageSize = 10;
+    public const int DefaultExtraSmallPageSize = 6;
     public const int DefaultExtraLargePageSize = 16;
 
     public const int FeaturedMinute = 0;

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -24,8 +24,7 @@ public static class Constants
     public const string UserMentionExample = "`@usermention` / `lfm:fm-bot` / `356268235697553409`";
 
     public const string BillboardExample = "`billboard` / `bb`";
-    public const string ExtraLargeExample = "`extralarge` / `xl`";
-    public const string ExtraSmallExample = "`extrasmall` / `xs`";
+    public const string EmbedSizeExample = "`extralarge` / `xl` / 'extrasmall' / 'xs'";
 
     public const string UserMentionOrLfmUserNameExample = "`fm-bot` / `@usermention` / `356268235697553409`";
 

--- a/src/FMBot.Domain/Constants.cs
+++ b/src/FMBot.Domain/Constants.cs
@@ -24,7 +24,7 @@ public static class Constants
     public const string UserMentionExample = "`@usermention` / `lfm:fm-bot` / `356268235697553409`";
 
     public const string BillboardExample = "`billboard` / `bb`";
-    public const string EmbedSizeExample = "`extralarge` / `xl` / 'extrasmall' / 'xs'";
+    public const string EmbedSizeExample = "`extralarge` / `xl` / `extrasmall` / `xs`";
 
     public const string UserMentionOrLfmUserNameExample = "`fm-bot` / `@usermention` / `356268235697553409`";
 

--- a/src/FMBot.Domain/Enums/EmbedSize.cs
+++ b/src/FMBot.Domain/Enums/EmbedSize.cs
@@ -1,0 +1,8 @@
+﻿namespace FMBot.Domain.Enums;
+
+public enum EmbedSize
+{
+    Default = Constants.DefaultPageSize,
+    Small = Constants.DefaultExtraSmallPageSize,
+    Large = Constants.DefaultExtraLargePageSize
+}


### PR DESCRIPTION
Hello!

I'm making this pull request for adding the small argument that was mentioned in [this help thread](https://discord.com/channels/821660544581763093/1155390194372059226/1155390194372059226). 

Instead of using a boolean for calling extraLarge as an embed size, I instead used an enum where the user can pick between different sizes. Moreover, for slash commands, the user can pick both "xxl" and "xxs" to be true, but I (somewhat arbitrarily) gave precedence to XXL in all cases (text or slash command). 

I tested it on a personal branch and while it seems that everything is working fine, I'd appreciate some more testing on the wider database that the develop bot has, especially for the `.taste` command as mine is very limited in scope. 

I hope this is of help,
Regor