### PR TITLE
more loosely match genres

### DIFF
--- a/src/FMBot.Bot/Builders/GenreBuilders.cs
+++ b/src/FMBot.Bot/Builders/GenreBuilders.cs
@@ -368,9 +368,9 @@ public class GenreBuilders
         }
         else
         {
-            var foundGenre = await this._genreService.GetValidGenre(genreOptions);
+            var foundGenres = await this._genreService.SearchThroughGenres(genreOptions);
 
-            if (foundGenre == null)
+            if (foundGenres == null)
             {
                 var artist = await this._artistsService.GetArtistFromDatabase(genreOptions);
 
@@ -405,7 +405,7 @@ public class GenreBuilders
                 return response;
             }
 
-            genres = new List<string> { foundGenre };
+            genres = foundGenres;
         }
 
         if (!genres.Any())

--- a/src/FMBot.Bot/Services/GenreService.cs
+++ b/src/FMBot.Bot/Services/GenreService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Dapper;
 using FMBot.Bot.Models;
@@ -142,11 +143,9 @@ public class GenreService
                 this._cache.Set(cacheKey, genres, TimeSpan.FromHours(2));
             }
 
-            var results = genres.Where(w => w.StartsWith(searchValue, StringComparison.OrdinalIgnoreCase)).ToList();
+            Regex rx = new(@"(?i)\b" + searchValue + @"\b");
 
-            results.AddRange(genres.Where(w => w.Contains(searchValue, StringComparison.OrdinalIgnoreCase)));
-
-            return results;
+            return genres.Where(w => rx.IsMatch(searchValue)).ToList();
         }
         catch (Exception e)
         {


### PR DESCRIPTION
the change in `GenreService` should improve the returned list of genres in the autocomplete for `/genre`.
the change in `GenreBuilders` should make it so that `.g rap` will return artists with genres such as `rap`, `k-rap`, `jazz rap` and `rap maroc` associated with them.

i've not started working on the suggested dropdown filter to narrow down the result of `.g`, so i could either start that in this pr or later.