### PR TITLE
Make stats' command's name field return realname

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ Logs/
 packages/
 src/.vs/
 .vs/
+
+.DS_Store

--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -640,7 +640,10 @@ public class UserBuilder
         }
 
         var lastFmStats = new StringBuilder();
-        lastFmStats.AppendLine($"Name: **{userInfo.Name}**");
+        if (userInfo.Name) 
+        {
+            lastFmStats.AppendLine($"Name: **{userInfo.Name}**");
+        }
         lastFmStats.AppendLine($"Username: **[{userSettings.UserNameLastFm}]({LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)})**");
         if (userInfo.Subscriber)
         {

--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -640,7 +640,7 @@ public class UserBuilder
         }
 
         var lastFmStats = new StringBuilder();
-        if !(string.IsNullOrWhiteSpace(userInfo.Name))
+        if (!string.IsNullOrWhiteSpace(userInfo.Name))
         {
             lastFmStats.AppendLine($"Name: **{userInfo.Name}**");
         }

--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -640,7 +640,7 @@ public class UserBuilder
         }
 
         var lastFmStats = new StringBuilder();
-        if (userInfo.Name) 
+        if !(string.IsNullOrWhiteSpace(userInfo.Name))
         {
             lastFmStats.AppendLine($"Name: **{userInfo.Name}**");
         }

--- a/src/FMBot.LastFM.Domain/Types/Calls.cs
+++ b/src/FMBot.LastFM.Domain/Types/Calls.cs
@@ -3,20 +3,20 @@ namespace FMBot.LastFM.Domain.Types;
 public class Call
 {
     public static readonly string
-        ArtistInfo = "Artist.getInfo",
-        AlbumInfo = "Album.getInfo",
-        TrackInfo = "Track.getInfo",
+        ArtistInfo = "artist.getInfo",
+        AlbumInfo = "album.getInfo",
+        TrackInfo = "track.getInfo",
         TrackLove = "track.love",
-        TrackUnLove = "track.unLove",
+        TrackUnLove = "track.unlove",
         TrackScrobble = "track.scrobble",
-        TrackUpdateNowPlaying = "track.updatenowplaying",
-        UserInfo = "User.getInfo",
+        TrackUpdateNowPlaying = "track.updateNowPlaying",
+        UserInfo = "user.getInfo",
         TopTracks = "user.getTopTracks",
         RecentTracks = "user.getRecentTracks",
         LovedTracks = "user.getLovedTracks",
         GetWeeklyArtistChart = "user.getWeeklyArtistChart",
         GetWeeklyAlbumChart = "user.getWeeklyAlbumChart",
         GetWeeklyTrackChart = "user.getWeeklyTrackChart",
-        GetToken = "auth.GetToken",
+        GetToken = "auth.getToken",
         GetAuthSession = "auth.getSession";
 }

--- a/src/FMBot.LastFM/Repositories/LastFmRepository.cs
+++ b/src/FMBot.LastFM/Repositories/LastFmRepository.cs
@@ -371,7 +371,7 @@ public class LastFmRepository : ILastfmRepository
             AlbumCount = userCall.Content.User.AlbumCount,
             ArtistCount = userCall.Content.User.ArtistCount,
             TrackCount = userCall.Content.User.TrackCount,
-            Name = userCall.Content.User.Name,
+            Name = userCall.Content.User.Realname,
             Country = userCall.Content.User.Country,
             Url = userCall.Content.User.Url.ToString(),
             Registered = DateTime.UnixEpoch.AddSeconds(userCall.Content.User.Registered.Unixtime).ToUniversalTime(),


### PR DESCRIPTION
Makes the stats command return a differing name to the username - does not rename the 'Name' field as such, but changes GetLfmUserInfoAsync to return Realname as the name - within the stats command (or more accurately, the UserBuilder) the term 'Username' is used to differentiate between the two values, and the 'Username' value isn't derived from GetLfmUserInfoAsync

[Here](https://github.com/fmbot-discord/fmbot/blob/dev/src/FMBot.Bot/Builders/UserBuilder.cs#L643)'s a link to the relevant lines within UserBuilder for convenience