### PR TITLE
fix discord link in CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 When contributing to this repository, please first discuss the change you wish 
-to make via issue, [our support Discord](https://discord.gg/5SZRGnJ), or any other 
+to make via issue, [our support Discord](https://discord.gg/fmbot), or any other 
 method with the owners of this repository before making a change. 
 
 If you make a useful pull request you will also get the contributor status in the 


### PR DESCRIPTION
Title - pretty simple fix but I noticed it the other day when submitting my other changes