### PR TITLE
fix returned midnight value

### DIFF
--- a/src/FMBot.Bot/Services/PlayService.cs
+++ b/src/FMBot.Bot/Services/PlayService.cs
@@ -69,7 +69,7 @@ public class PlayService
             {
                 Days = plays
                     .OrderByDescending(o => o.TimePlayed)
-                    .GroupBy(g => TimeZoneInfo.ConvertTime(g.TimePlayed.Date, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)))
+                    .GroupBy(g => TimeZoneInfo.ConvertTime(g.TimePlayed, TimeZoneInfo.FindSystemTimeZoneById(timeZoneId)).Date)
                     .Select(s => new DayOverview
                     {
                         Date = s.Key,

--- a/src/FMBot.Bot/SlashCommands/UserSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/UserSlashCommands.cs
@@ -601,7 +601,9 @@ public class UserSlashCommands : InteractionModuleBase
         var newTimeZone = await this._userService.SetTimeZone(userSettings.UserId, timezone);
 
         var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(newTimeZone);
-        var dateValue = ((DateTimeOffset)TimeZoneInfo.ConvertTime(DateTime.UtcNow.AddDays(1).Date, timeZoneInfo))
+        var localTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, timeZoneInfo);
+        var nextMidnight = localTime.Date.AddDays(1);
+        var dateValue = ((DateTimeOffset)TimeZoneInfo.ConvertTimeToUtc(nextMidnight, timeZoneInfo))
             .ToUnixTimeSeconds();
 
         var reply = new StringBuilder();


### PR DESCRIPTION
Seems as though it returns the wrong date and time within the localization return (as seen below) - this is a fix which (I believe) corrects it (based on my small 
isolated testing of the fix).

![image](https://github.com/fmbot-discord/fmbot/assets/24910512/053b6e89-a290-47ef-b1e1-e7c470b95ba1)
![image](https://github.com/fmbot-discord/fmbot/assets/24910512/e437eadd-4429-4a82-ab08-b09f4b6f8a10)

