### PR TITLE
Add Red music bot support (and fix a small null reference bug)

### DIFF
--- a/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
+++ b/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
@@ -18,7 +18,6 @@ using FMBot.Domain.Enums;
 using FMBot.Domain.Extensions;
 using FMBot.Domain.Models;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
 
 namespace FMBot.Bot.Builders;
 

--- a/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
+++ b/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
@@ -170,6 +170,8 @@ public class GuildSettingBuilder
             response.Embed.AddField("Missing server-wide permissions", serverPermission.ToString());
         }
 
+        response.Embed.AddField("Red bot name", guild.RedBotName ?? "N/A");
+
         var guildSettings = new SelectMenuBuilder()
             .WithPlaceholder("Select setting you want to change")
             .WithCustomId(InteractionConstants.GuildSetting)
@@ -946,6 +948,43 @@ public class GuildSettingBuilder
         {
             components
                 .WithButton("Enable bot in channel", $"{InteractionConstants.ToggleCommand.ToggleCommandEnableAll}-{selectedChannel.Id}-{selectedCategoryId}", style: ButtonStyle.Primary, row: 1);
+        }
+
+        response.Components = components;
+
+        return response;
+    }
+
+    public async Task<ResponseModel> SetRedBotName(ContextModel context, IUser lastModifier = null)
+    {
+        var response = new ResponseModel
+        {
+            ResponseType = ResponseType.Embed,
+        };
+
+        response.Embed.WithTitle("Set Red bot name");
+        response.Embed.WithColor(DiscordConstants.InformationColorBlue);
+
+        var description = new StringBuilder();
+        var guild = await this._guildService.GetGuildAsync(context.DiscordGuild.Id);
+
+        var redBotName = guild.RedBotName;
+
+        description.AppendLine();
+        description.AppendLine($"Current name: `{redBotName ?? "N/A"}`");
+        description.AppendLine();
+        description.AppendLine("Your Red bot instance's name must start with, or be the same as, the name you enter.");
+        description.AppendLine();
+
+        var components = new ComponentBuilder();
+
+        components.WithButton("Set Red bot name", InteractionConstants.SetRedBotName, style: ButtonStyle.Primary);
+
+        response.Embed.WithDescription(description.ToString());
+
+        if (lastModifier != null)
+        {
+            response.Embed.WithFooter($"Last modified by {lastModifier.Username}");
         }
 
         response.Components = components;

--- a/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
+++ b/src/FMBot.Bot/Builders/GuildSettingBuilder.cs
@@ -18,6 +18,7 @@ using FMBot.Domain.Enums;
 using FMBot.Domain.Extensions;
 using FMBot.Domain.Models;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 
 namespace FMBot.Bot.Builders;
 

--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -175,7 +175,8 @@ public class UserBuilder
                                     "Currently supported bots:\n" +
                                     "- Cakey Bot\n" +
                                     "- Jockie Music\n" +
-                                    "- SoundCloud"
+                                    "- SoundCloud\n" +
+                                    "- Red"
                                     );
 
         response.Components = new ComponentBuilder()

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -144,7 +144,7 @@ public class CommandHandler
     {
         foreach (var musicBot in MusicBot.SupportedBots)
         {
-            if (musicBot.IsAuthor(msg.Author))
+            if (await musicBot.IsAuthor(msg.Author, context, this._guildService))
             {
                 await this._musicBotService.Scrobble(musicBot, msg, context);
                 break;

--- a/src/FMBot.Bot/Models/Modals/SettingModals.cs
+++ b/src/FMBot.Bot/Models/Modals/SettingModals.cs
@@ -92,3 +92,12 @@ public class AddDisabledGuildCommandModal : IModal
     [ModalTextInput("command", placeholder: "whoknows", minLength: 1, maxLength: 40)]
     public string Command { get; set; }
 }
+
+public class SetRedBotNameModal : IModal
+{
+    public string Title => "Set Red bot name";
+
+    [InputLabel("Enter new bot name")]
+    [ModalTextInput("red_bot_name", minLength: 1, maxLength: 15)]
+    public string NewBotName { get; set; }
+}

--- a/src/FMBot.Bot/Models/MusicBot/MusicBot.cs
+++ b/src/FMBot.Bot/Models/MusicBot/MusicBot.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Discord;
+using Discord.Commands;
 using Discord.WebSocket;
+using FMBot.Bot.Services.Guild;
 
 namespace FMBot.Bot.Models.MusicBot;
 
@@ -16,7 +19,8 @@ public abstract class MusicBot
     {
         new JockieMusicBot(),
         new CakeyBotMusicBot(),
-        new SoundCloudMusicBot()
+        new SoundCloudMusicBot(),
+        new RedMusicBot()
     };
 
     protected MusicBot(string name, bool possiblyIncludesLinks = true, bool skipUploaderName = false)
@@ -26,7 +30,7 @@ public abstract class MusicBot
         this.SkipUploaderName = skipUploaderName;
     }
 
-    public bool IsAuthor(SocketUser user)
+    public virtual async Task<bool> IsAuthor(SocketUser user, ICommandContext context, GuildService guildService)
     {
         return user?.Username?.StartsWith(this.Name, StringComparison.OrdinalIgnoreCase) ?? false;
     }

--- a/src/FMBot.Bot/Models/MusicBot/RedMusicBot.cs
+++ b/src/FMBot.Bot/Models/MusicBot/RedMusicBot.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using FMBot.Bot.Services.Guild;
+
+namespace FMBot.Bot.Models.MusicBot;
+
+internal class RedMusicBot : MusicBot
+{
+    public RedMusicBot() : base("Red", true, true)
+    {
+    }
+
+    public override bool ShouldIgnoreMessage(IUserMessage msg)
+    {
+        // Bot sends only single embed per request
+        if (msg.Embeds.Count != 1)
+        {
+            return true;
+        }
+
+        var targetEmbed = msg.Embeds.First();
+
+        return targetEmbed.Title == null ||
+               !targetEmbed.Title.Contains("Now Playing") ||
+               string.IsNullOrEmpty(targetEmbed.Description);
+    }
+
+    public override string GetTrackQuery(IUserMessage msg)
+    {
+        return msg.Embeds.First().Description;
+    }
+
+    public override async Task<bool> IsAuthor(SocketUser user, ICommandContext context, GuildService guildService)
+    {
+        var guild = await guildService.GetGuildAsync(context.Guild.Id);
+        string redBotName = guild.RedBotName;
+
+        if (redBotName != null)
+        {
+            return user?.Username?.StartsWith(redBotName, StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+
+        return false;
+    }
+}

--- a/src/FMBot.Bot/Models/MusicBot/RedMusicBot.cs
+++ b/src/FMBot.Bot/Models/MusicBot/RedMusicBot.cs
@@ -10,7 +10,7 @@ namespace FMBot.Bot.Models.MusicBot;
 
 internal class RedMusicBot : MusicBot
 {
-    public RedMusicBot() : base("Red", true, true)
+    public RedMusicBot() : base("Red", true, false)
     {
     }
 
@@ -31,7 +31,7 @@ internal class RedMusicBot : MusicBot
 
     public override string GetTrackQuery(IUserMessage msg)
     {
-        return msg.Embeds.First().Description;
+        return msg.Embeds.First().Description.Replace(@"\","");
     }
 
     public override async Task<bool> IsAuthor(SocketUser user, ICommandContext context, GuildService guildService)

--- a/src/FMBot.Bot/Resources/InteractionConstants.cs
+++ b/src/FMBot.Bot/Resources/InteractionConstants.cs
@@ -126,6 +126,9 @@ public static class InteractionConstants
         public const string ToggleGuildCommandRemoveModal = "toggle-guild-command-modal-remove";
     }
 
+    public const string SetRedBotName = "set-red-bot-name";
+    public const string SetRedBotNameModal = "set-red-bot-name-modal";
+
     public const string WhoKnowsRolePicker = "whoknows-role-picker";
     public const string WhoKnowsAlbumRolePicker = "whoknows-album-role-picker";
     public const string WhoKnowsTrackRolePicker = "whoknows-track-role-picker";

--- a/src/FMBot.Bot/Services/TimerService.cs
+++ b/src/FMBot.Bot/Services/TimerService.cs
@@ -88,9 +88,11 @@ public class TimerService
         Log.Information($"RecurringJob: Adding {nameof(ClearUserCache)}");
         RecurringJob.AddOrUpdate(nameof(ClearUserCache), () => ClearUserCache(), "30 */2 * * *");
 
+        Log.Information($"Bot Settings: {ConfigData.Data.Shards}");
+
         if (this._botSettings.LastFm.UserIndexFrequencyInDays != null &&
             this._botSettings.LastFm.UserIndexFrequencyInDays != 0 &&
-            ConfigData.Data.Shards.MainInstance == true)
+            ConfigData.Data.Shards?.MainInstance == true)
         {
             Log.Information($"RecurringJob: Adding {nameof(AddUsersToIndexQueue)}");
             RecurringJob.AddOrUpdate(nameof(AddUsersToIndexQueue), () => AddUsersToIndexQueue(), "0 8 * * *");
@@ -102,7 +104,7 @@ public class TimerService
 
         if (this._botSettings.LastFm.UserUpdateFrequencyInHours != null &&
             this._botSettings.LastFm.UserUpdateFrequencyInHours != 0 &&
-            ConfigData.Data.Shards.MainInstance == true)
+            ConfigData.Data.Shards?.MainInstance == true)
         {
             Log.Information($"RecurringJob: Adding {nameof(AddUsersToUpdateQueue)}");
             RecurringJob.AddOrUpdate(nameof(AddUsersToUpdateQueue), () => AddUsersToUpdateQueue(), "0 * * * *");

--- a/src/FMBot.Bot/Services/TrackService.cs
+++ b/src/FMBot.Bot/Services/TrackService.cs
@@ -385,7 +385,23 @@ public class TrackService
                     }
                 }
 
+                // Sometimes track and artist are reversed (esp. with YouTube bots, e.g. "Title - Artist - Topic")
+                // Use the order with the most listeners
                 var trackLfm = await this._dataSourceFactory.GetTrackInfoAsync(trackName, artistName);
+                var trackLfmReversed = await this._dataSourceFactory.GetTrackInfoAsync(artistName, trackName);
+
+                if (trackLfm.Success && trackLfmReversed.Success)
+                {
+                    trackLfm = trackLfm.Content.TotalListeners >= trackLfmReversed.Content.TotalListeners
+                        ? trackLfm
+                        : trackLfmReversed;
+                }
+                else
+                {
+                    // Try to use the reversed if the normal order is not successful
+                    trackLfm = trackLfm.Success ? trackLfm : trackLfmReversed;
+                }
+
 
                 if (trackLfm.Success)
                 {

--- a/src/FMBot.Bot/SlashCommands/GuildSettingSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/GuildSettingSlashCommands.cs
@@ -242,6 +242,12 @@ public class GuildSettingSlashCommands : InteractionModuleBase
                         await this.Context.SendResponse(this.Interactivity, response, ephemeral: false);
                     }
                     break;
+                case GuildSetting.RedBotName:
+                {
+                    response = await this._guildSettingBuilder.SetRedBotName(new ContextModel(this.Context));
+                    await this.Context.SendResponse(this.Interactivity, response, ephemeral: false);
+                }
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -788,5 +794,29 @@ public class GuildSettingSlashCommands : InteractionModuleBase
         var response = await this._guildSettingBuilder.ToggleGuildCommand(new ContextModel(this.Context), this.Context.User);
 
         await this.Context.UpdateInteractionEmbed(response);
+    }
+
+    [ComponentInteraction(InteractionConstants.SetRedBotName)]
+    [ServerStaffOnly]
+    public async Task SetRedBotName()
+    {
+        var message = (this.Context.Interaction as SocketMessageComponent)?.Message;
+
+        if (message == null)
+        {
+            return;
+        }
+
+        await this.Context.Interaction.RespondWithModalAsync<SetRedBotNameModal>($"{InteractionConstants.SetRedBotNameModal}-{message.Id}");
+    }
+
+    [ModalInteraction($"{InteractionConstants.SetRedBotNameModal}-*")]
+    [ServerStaffOnly]
+    public async Task SetRedBotName(string messageId, SetRedBotNameModal modal)
+    {
+        await this._guildService.SetGuildRedBotNameAsync(this.Context.Guild, modal.NewBotName);
+
+        var response = await this._guildSettingBuilder.SetRedBotName(new ContextModel(this.Context), this.Context.User);
+        await this.Context.UpdateMessageEmbed(response, messageId);
     }
 }

--- a/src/FMBot.Domain/Enums/GuildSetting.cs
+++ b/src/FMBot.Domain/Enums/GuildSetting.cs
@@ -29,7 +29,9 @@ public enum GuildSetting
 
     [Option("Disabled channel commands", "Toggle commands or the bot per channel")]
     DisabledCommands = 30,
-
     [Option("Disabled server commands", "Toggle commands server-wide")]
     DisabledGuildCommands = 31,
+    
+    [Option("Red bot name", "Name of Red bot instance for music bot scrobbling")]
+    RedBotName = 40,
 }

--- a/src/FMBot.Persistence.Domain/Models/Guild.cs
+++ b/src/FMBot.Persistence.Domain/Models/Guild.cs
@@ -60,4 +60,6 @@ public class Guild
     public ICollection<Webhook> Webhooks { get; set; }
 
     public ulong? WhoKnowsWhitelistRoleId { get; set; }
+
+    public string? RedBotName { get; set; }
 }

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20231207235943_AddRedBotName.Designer.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20231207235943_AddRedBotName.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using FMBot.Persistence.EntityFrameWork;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FMBot.Persistence.EntityFrameWork.Migrations
 {
     [DbContext(typeof(FMBotDbContext))]
-    partial class FMBotDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231207235943_AddRedBotName")]
+    partial class AddRedBotName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/FMBot.Persistence.EntityFrameWork/Migrations/20231207235943_AddRedBotName.cs
+++ b/src/FMBot.Persistence.EntityFrameWork/Migrations/20231207235943_AddRedBotName.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FMBot.Persistence.EntityFrameWork.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRedBotName : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "red_bot_name",
+                table: "guilds",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "red_bot_name",
+                table: "guilds");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for [Red](https://github.com/Cog-Creators/Red-DiscordBot) as a music bot.

The way that I've done this integration (since Red is a self-hosted bot) is to make the name of the bot configurable via `.configuration`. If this would be better done some other way I'd be happy to make changes to that effect.

Additionally, a issue I've run into is that artist and song title will sometimes be reversed (especially if the upload channel is the name of the artist, or a "topic channel"); this PR adds a check for which order has the most listeners on Last.fm and uses the one that's higher. If that's too big of a change, it might make sense to check for "- Topic" specifically and flip the artist/title around only if it's a topic channel (which will miss more wrong-way-around scrobbles, but be a smaller change.)

I also fixed https://github.com/fmbot-discord/fmbot/issues/267 in the process (which was preventing me from running the bot in the first place.)

(I'd also be happy to DM anyone an invite link for my personal Red bot instance for testing, if needed)