### PR TITLE
Fix the Bot disabled message being sent when the command isn't valid

### DIFF
--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -398,9 +398,9 @@ public class CommandHandler
             if (channelDisabled)
             {
                 if (searchResult.Commands == null || !searchResult.Commands.Any())
-                    {
-                        return false;
-                    }
+                {
+                    return false;
+                }
                 _ = this._interactiveService.DelayedDeleteMessageAsync(
                     await context.Channel.SendMessageAsync("The bot has been disabled in this channel."),
                     TimeSpan.FromSeconds(8));

--- a/src/FMBot.Bot/Handlers/CommandHandler.cs
+++ b/src/FMBot.Bot/Handlers/CommandHandler.cs
@@ -397,6 +397,10 @@ public class CommandHandler
             var channelDisabled = DisabledChannelService.GetDisabledChannel(context.Channel.Id);
             if (channelDisabled)
             {
+                if (searchResult.Commands == null || !searchResult.Commands.Any())
+                    {
+                        return false;
+                    }
                 _ = this._interactiveService.DelayedDeleteMessageAsync(
                     await context.Channel.SendMessageAsync("The bot has been disabled in this channel."),
                     TimeSpan.FromSeconds(8));


### PR DESCRIPTION
The bot disabled message should only be sent when the command attempted is valid

Undesired behavior:
![image](https://github.com/fmbot-discord/fmbot/assets/126067139/5ea7dfe5-7548-4e71-b59e-27bde472fc0d)
