### PR TITLE
order by name length, place the longest artist name in the center in sections of length >=3

### DIFF
--- a/src/FMBot.Images/Generators/PuppeteerService.cs
+++ b/src/FMBot.Images/Generators/PuppeteerService.cs
@@ -643,20 +643,21 @@ public class PuppeteerService
             ],
             3 =>
             [
-                new ArtistNamePosition(2, ImageWidth - margin, topY + 15),
                 new ArtistNamePosition(3, ImageWidth / 2, middleY + 20),
+                new ArtistNamePosition(2, ImageWidth - margin, topY + 15),
                 new ArtistNamePosition(4, margin, topY + 15),
             ],
             _ =>
             [
+                new ArtistNamePosition(3, ImageWidth / 2, middleY),
                 new ArtistNamePosition(1, margin, topY),
                 new ArtistNamePosition(2, ImageWidth - margin, topY),
-                new ArtistNamePosition(3, ImageWidth / 2, middleY),
                 new ArtistNamePosition(4, margin, bottomY),
                 new ArtistNamePosition(5, ImageWidth - margin, bottomY)
             ]
         };
     }
+
 
     public void CreatePopularityIcebergImage(SKBitmap chartImage, string username, string timePeriod,
         List<ArtistPopularity> artists)
@@ -719,12 +720,13 @@ public class PuppeteerService
                     a.Popularity > minPopularity && a.Popularity <= maxPopularity)
                 .OrderByDescending(a => a.Playcount)
                 .Take(5)
+                .OrderByDescending(a => a.Name.Length)
                 .ToList();
 
             var sectionY = FirstArtistY + (section * (totalAvailableHeight / TotalSections));
             var positions = GenerateArtistNamePositions(sectionY, sectionArtists.Count);
 
-            for (var i = 0; i < Math.Min(sectionArtists.Count, 5); i++)
+            for (var i = 0; i < sectionArtists.Count; i++)
             {
                 var position = positions[i];
                 var isWhiteText = position.Y >= TextColorChangeY;


### PR DESCRIPTION
As it stands, artists whose names are beyond ~29 characters end up clipping the image if they're placed in the slots near the edges.

This is by no means a _good_ fix, but helps the generation by

1. ordering the up to 5 element long list by artist name length (longest first)
2. in the cases where `sectionArtistsCount` is 3, 4 or 5, place the longest name in the center.

This does not fix cases where 2 or more artists in a given section have a name longer than 29 characters.

... mind, I have not yet set up an environment where I can test the result of this change myself :(

---

Perhaps in the future one could look into bumping the positions along the `x` axis to avoid clipping, if possible.
In that case, another reordering of `GenerateArtistNamePositions` might be useful so that the longest named artist has the shortest named "neighbor" so to speak (to give it the most space to readjust)