### PR TITLE
feat: Display alt count in 'Too Many Accounts' login error

### DIFF
--- a/src/FMBot.Bot/Builders/UserBuilder.cs
+++ b/src/FMBot.Bot/Builders/UserBuilder.cs
@@ -318,7 +318,7 @@ public class UserBuilder
         return response;
     }
 
-    public static ResponseModel LoginTooManyAccounts()
+    public static ResponseModel LoginTooManyAccounts(int altCount)
     {
         var response = new ResponseModel
         {
@@ -327,7 +327,7 @@ public class UserBuilder
 
         var description = new StringBuilder();
         description.AppendLine(
-            $"Can't login, this Last.fm is connected to too many Discord accounts already (max is {Constants.MaxAlts}).");
+            $"Can't login, this Last.fm is connected to too many Discord accounts already ({altCount}/{Constants.MaxAlts}).");
         description.AppendLine("");
         description.AppendLine("To delete and transfer data from your other .fmbot accounts:");
         description.AppendLine("1. Use 'Manage alts'");

--- a/src/FMBot.Bot/Services/UserService.cs
+++ b/src/FMBot.Bot/Services/UserService.cs
@@ -1301,7 +1301,7 @@ public class UserService
         TimedOut
     }
 
-    public async Task<LoginStatus> GetAndStoreAuthSession(IUser contextUser, string token)
+    public async Task<(LoginStatus Status, int AltCount)> GetAndStoreAuthSession(IUser contextUser, string token)
     {
         Log.Information("LastfmAuth: Login session starting for {user} | {discordUserId}", contextUser.Username,
             contextUser.Id);
@@ -1338,18 +1338,18 @@ public class UserService
                     Log.Information(
                         "LastfmAuth: Too many accounts already connected to {userName} - {altCount} alts (discordUserId: {discordUserId})",
                         userSettings.UserNameLastFM, existingUserCount, contextUser.Id);
-                    return LoginStatus.TooManyAccounts;
+                    return (LoginStatus.TooManyAccounts, existingUserCount);
                 }
 
                 await SetLastFm(contextUser, userSettings, true);
-                return LoginStatus.Success;
+                return (LoginStatus.Success, 0);
             }
 
             if (!authSession.Success && i == 10)
             {
                 Log.Information("LastfmAuth: Login timed out or auth not successful (discordUserId: {discordUserId})",
                     contextUser.Id);
-                return LoginStatus.TimedOut;
+                return (LoginStatus.TimedOut, 0);
             }
 
             if (!authSession.Success)
@@ -1358,7 +1358,7 @@ public class UserService
             }
         }
 
-        return LoginStatus.TimedOut;
+        return (LoginStatus.TimedOut, 0);
     }
 
     public async Task<PrivacyLevel> SetPrivacyLevel(int userId, PrivacyLevel privacyLevel)

--- a/src/FMBot.Bot/SlashCommands/UserSlashCommands.cs
+++ b/src/FMBot.Bot/SlashCommands/UserSlashCommands.cs
@@ -299,9 +299,9 @@ public class UserSlashCommands : InteractionModuleBase
                 components: loginUrlResponse.Components.Build());
             this.Context.LogCommandUsed(CommandResponse.UsernameNotSet);
 
-            var loginStatus = await this._userService.GetAndStoreAuthSession(this.Context.User, token.Content.Token);
+            var loginResult = await this._userService.GetAndStoreAuthSession(this.Context.User, token.Content.Token);
 
-            if (loginStatus == UserService.LoginStatus.Success)
+            if (loginResult.Status == UserService.LoginStatus.Success)
             {
                 var newUserSettings = await this._userService.GetUserSettingsAsync(this.Context.User);
 
@@ -358,9 +358,9 @@ public class UserSlashCommands : InteractionModuleBase
                     }
                 }
             }
-            else if (loginStatus == UserService.LoginStatus.TooManyAccounts)
+            else if (loginResult.Status == UserService.LoginStatus.TooManyAccounts)
             {
-                var loginFailure = UserBuilder.LoginTooManyAccounts();
+                var loginFailure = UserBuilder.LoginTooManyAccounts(loginResult.AltCount); // Pass AltCount here
                 await FollowupAsync(null, [loginFailure.Embed.Build()], components: loginFailure.Components.Build(),
                     ephemeral: true);
 


### PR DESCRIPTION
When you attempt to log in and have too many existing accounts linked to your Last.fm profile, the error message will now display the current number of linked accounts versus the maximum allowed.

This provides better context to you, helping you understand why the login is failing and guiding you towards the 'Manage alts' functionality.

Changes made:
- Modified `UserService.GetAndStoreAuthSession` to return the `existingUserCount` when `LoginStatus.TooManyAccounts` occurs.
- Updated `UserSlashCommands.LoginButtonAsync` to receive this count and pass it to the message builder.
- Modified `UserBuilder.LoginTooManyAccounts` to accept the `altCount` and include it in the displayed error message.