### PR TITLE
remove extra spaces in PlayBuilders.cs commands

### DIFF
--- a/src/FMBot.Bot/Builders/PlayBuilders.cs
+++ b/src/FMBot.Bot/Builders/PlayBuilders.cs
@@ -288,14 +288,14 @@ public class PlayBuilder
         if (userSettings.DisplayName.ContainsEmoji())
         {
             embedTitle = !userSettings.DifferentUser
-                ? $"{userSettings.DisplayName} {userSettings.UserType.UserTypeToIcon()}"
-                : $"{userSettings.DisplayName} {userSettings.UserType.UserTypeToIcon()}, requested by {requesterUserTitle}";
+                ? $"{userSettings.DisplayName}{userSettings.UserType.UserTypeToIcon()}"
+                : $"{userSettings.DisplayName}{userSettings.UserType.UserTypeToIcon()}, requested by {requesterUserTitle}";
         }
         else
         {
             embedTitle = !userSettings.DifferentUser
-                ? $"[{userSettings.DisplayName}](<{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}>) {userSettings.UserType.UserTypeToIcon()}"
-                : $"[{userSettings.DisplayName}](<{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}>) {userSettings.UserType.UserTypeToIcon()}, requested by {requesterUserTitle}";
+                ? $"[{userSettings.DisplayName}](<{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}>){userSettings.UserType.UserTypeToIcon()}"
+                : $"[{userSettings.DisplayName}](<{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}>){userSettings.UserType.UserTypeToIcon()}, requested by {requesterUserTitle}";
         }
         // var embed = await this._userService.GetTemplateFmAsync(context.ContextUser.UserId, userSettings, currentTrack,
         //     previousTrack, totalPlaycount, guild, guildUsers);
@@ -894,7 +894,7 @@ public class PlayBuilder
             var container = new ComponentContainerProperties();
 
             container.WithTextDisplay(
-                $"### Recent tracks for {StringExtensions.MarkdownLink(StringExtensions.Sanitize(userSettings.DisplayName), recentTracks.Content.UserRecentTracksUrl)} {userSettings.UserType.UserTypeToIcon()}");
+                $"### Recent tracks for {StringExtensions.MarkdownLink(StringExtensions.Sanitize(userSettings.DisplayName), recentTracks.Content.UserRecentTracksUrl)}{userSettings.UserType.UserTypeToIcon()}");
 
             foreach (var track in trackPage)
             {
@@ -1271,7 +1271,7 @@ public class PlayBuilder
             var container = new ComponentContainerProperties();
 
             container.WithTextDisplay(
-                $"### Daily overview for {StringExtensions.MarkdownLink(StringExtensions.Sanitize(userSettings.DisplayName), $"{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}/library?date_preset=LAST_7_DAYS")} {userSettings.UserType.UserTypeToIcon()}");
+                $"### Daily overview for {StringExtensions.MarkdownLink(StringExtensions.Sanitize(userSettings.DisplayName), $"{LastfmUrlExtensions.GetUserUrl(userSettings.UserNameLastFm)}/library?date_preset=LAST_7_DAYS")}{userSettings.UserType.UserTypeToIcon()}");
 
             container.WithSeparator();
 


### PR DESCRIPTION
fixes:
- icon-havers are currently getting double spaces before the icon in these commands
- non-icon-havers get an erroneous space before the comma when requested by a different user

this is because UserTypeToIcon already adds a space for each icon
https://github.com/fmbot-discord/fmbot/blob/3c370cd5ad9ca38c1d8454d1bd08d99b2770cbd6/src/FMBot.Bot/Extensions/StringExtensions.cs#L145-L160