### PR TITLE
Fix track length lookup passing artist name twice

### DIFF
--- a/src/FMBot.Bot/Services/TimeService.cs
+++ b/src/FMBot.Bot/Services/TimeService.cs
@@ -137,7 +137,7 @@ public class TimeService
 
                 if (trackPlaycount > 0)
                 {
-                    var trackLength = track.DurationSeconds ?? (int)(await GetTrackLengthForTrack(track.ArtistName, track.ArtistName)).TotalSeconds;
+                    var trackLength = track.DurationSeconds ?? (int)(await GetTrackLengthForTrack(track.ArtistName, track.TrackName)).TotalSeconds;
 
                     timeListenedSeconds += (trackLength * trackPlaycount);
                     playsLeft -= trackPlaycount;


### PR DESCRIPTION
`GetAllTimePlayTimeForAlbum` falls back to `GetTrackLengthForTrack(track.ArtistName, track.ArtistName)` when an `AlbumTrack` has no stored `DurationSeconds`. The second arg should be `track.TrackName`.

Because `UseAverages = true`, the lookup silently returns the artist's average instead of failing, so album playtime estimates were variance-blind for every track missing a stored duration.