### PR TITLE
fix + and space handling in some commands, plus grammar

### DIFF
--- a/src/FMBot.Bot/Builders/CrownBuilders.cs
+++ b/src/FMBot.Bot/Builders/CrownBuilders.cs
@@ -117,7 +117,7 @@ public class CrownBuilders
             .First();
 
         var userArtistUrl =
-            $"{LastfmUrlExtensions.GetUserUrl(users[currentCrown.UserId].UserNameLastFM)}/library/music/{HttpUtility.UrlEncode(artistSearch.Artist.ArtistName)}";
+            LastfmUrlExtensions.GetUserMusicLibraryUrl(users[currentCrown.UserId].UserNameLastFM, artistSearch.Artist.ArtistName);
 
         guildUsers.TryGetValue(currentCrown.UserId, out var currentGuildUser);
         response.Embed.AddField("Current crown holder", CrownToString(currentGuildUser, users[currentCrown.UserId], currentCrown, context.NumberFormat, userArtistUrl));

--- a/src/FMBot.Bot/Extensions/StringExtensions.cs
+++ b/src/FMBot.Bot/Extensions/StringExtensions.cs
@@ -460,7 +460,7 @@ public static partial class StringExtensions
             return months <= 1 ? "one month ago" : months + " months ago";
         }
 
-        return "more then a month ago";
+        return "more than a month ago";
     }
 
     public static string GetTimeAgoShortString(DateTime timeAgo)

--- a/src/FMBot.Bot/Services/PlayService.cs
+++ b/src/FMBot.Bot/Services/PlayService.cs
@@ -503,7 +503,7 @@ public class PlayService
         var description = new StringBuilder();
         if (streak.ArtistName != null && streak.ArtistPlaycount.HasValue)
         {
-            var artistDisplay = HttpUtility.UrlEncode(streak.ArtistName).Length > 80
+            var artistDisplay = LastfmUrlExtensions.Encode(streak.ArtistName).Length > 80
                 ? $"**{streak.ArtistName}**"
                 : $"**[{streak.ArtistName}]({LastfmUrlExtensions.GetArtistUrl(streak.ArtistName)})**";
 
@@ -514,9 +514,9 @@ public class PlayService
 
         if (streak.AlbumName != null && streak.AlbumPlaycount.HasValue)
         {
-            var albumDisplay = HttpUtility.UrlEncode(streak.AlbumName).Length + HttpUtility.UrlEncode(streak.ArtistName ?? "").Length > 100
+            var albumDisplay = LastfmUrlExtensions.Encode(streak.AlbumName).Length + LastfmUrlExtensions.Encode(streak.ArtistName ?? "").Length > 100
                 ? $"**{streak.AlbumName}**"
-                : $"**[{streak.AlbumName}](https://www.last.fm/music/{HttpUtility.UrlEncode(streak.ArtistName)}/{HttpUtility.UrlEncode(streak.AlbumName)})**";
+                : $"**[{streak.AlbumName}]({LastfmUrlExtensions.GetAlbumUrl(streak.ArtistName, streak.AlbumName)})**";
 
             description.AppendLine(
                 $"` Album:` {albumDisplay} - " +
@@ -525,9 +525,9 @@ public class PlayService
 
         if (streak.TrackName != null && streak.TrackPlaycount.HasValue)
         {
-            var trackDisplay = HttpUtility.UrlEncode(streak.TrackName).Length + HttpUtility.UrlEncode(streak.ArtistName ?? "").Length > 100
+            var trackDisplay = LastfmUrlExtensions.Encode(streak.TrackName).Length + LastfmUrlExtensions.Encode(streak.ArtistName ?? "").Length > 100
                 ? $"**{streak.TrackName}**"
-                : $"**[{streak.TrackName}](https://www.last.fm/music/{HttpUtility.UrlEncode(streak.ArtistName)}/_/{HttpUtility.UrlEncode(streak.TrackName)})**";
+                : $"**[{streak.TrackName}]({LastfmUrlExtensions.GetTrackUrl(streak.ArtistName, streak.TrackName)})**";
 
             description.AppendLine(
                 $"` Track:` {trackDisplay} - " +

--- a/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
+++ b/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
@@ -39,7 +39,7 @@ public static class LastfmUrlExtensions
             return null;
         }
 
-        return $"https://last.fm/music/{LastfmUrlExtensions.Encode}/_/{encodedTrackName}";
+        return $"https://last.fm/music/{LastfmUrlExtensions.Encode(artistName)}/_/{encodedTrackName}";
     }
 
     public static string GetUserUrl(string userName, string addOn = null)

--- a/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
+++ b/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
@@ -1,12 +1,16 @@
-using System.Text.Encodings.Web;
+using System.Web;
 
 namespace FMBot.Domain.Extensions;
 
 public static class LastfmUrlExtensions
 {
+	private static string Encode(string name) {
+		return HttpUtility.UrlEncode(name).Replace("%2b", "%252B");
+	}
+	
     public static string GetArtistUrl(string artistName)
     {
-        return $"https://last.fm/music/{UrlEncoder.Default.Encode(artistName)}";
+        return $"https://last.fm/music/{LastfmUrlExtensions.Encode(artistName)}";
     }
 
     public static string GetAlbumUrl(string artistName, string albumName)
@@ -16,31 +20,31 @@ public static class LastfmUrlExtensions
             return null;
         }
 
-        var encodedAlbumName = UrlEncoder.Default.Encode(albumName);
+        var encodedAlbumName = LastfmUrlExtensions.Encode(albumName);
 
         if (encodedAlbumName.Length > 400)
         {
             return null;
         }
 
-        return $"https://last.fm/music/{UrlEncoder.Default.Encode(artistName)}/{encodedAlbumName}";
+        return $"https://last.fm/music/{LastfmUrlExtensions.Encode(artistName)}/{encodedAlbumName}";
     }
 
     public static string GetTrackUrl(string artistName, string trackName)
     {
-        var encodedTrackName = UrlEncoder.Default.Encode(trackName);
+        var encodedTrackName = LastfmUrlExtensions.Encode(trackName);
 
         if (encodedTrackName.Length > 400)
         {
             return null;
         }
 
-        return $"https://last.fm/music/{UrlEncoder.Default.Encode(artistName)}/_/{encodedTrackName}";
+        return $"https://last.fm/music/{LastfmUrlExtensions.Encode}/_/{encodedTrackName}";
     }
 
     public static string GetUserUrl(string userName, string addOn = null)
     {
-        var url =  $"https://last.fm/user/{UrlEncoder.Default.Encode(userName)}";
+        var url =  $"https://last.fm/user/{LastfmUrlExtensions.Encode(userName)}";
 
         if (addOn != null)
         {
@@ -52,11 +56,11 @@ public static class LastfmUrlExtensions
 
     public static string GetUserMusicLibraryUrl(string userName, string artist, string albumName = null, string trackName = null)
     {
-        var url =  $"https://last.fm/user/{UrlEncoder.Default.Encode(userName)}/library/music/{UrlEncoder.Default.Encode(artist)}";
+        var url =  $"https://last.fm/user/{LastfmUrlExtensions.Encode(userName)}/library/music/{LastfmUrlExtensions.Encode(artist)}";
 
         if (albumName != null)
         {
-            url += $"/{UrlEncoder.Default.Encode(albumName)}";
+            url += $"/{LastfmUrlExtensions.Encode(albumName)}";
         }
         if (albumName == null && trackName != null)
         {
@@ -64,7 +68,7 @@ public static class LastfmUrlExtensions
         }
         if (trackName != null)
         {
-            url += $"/{UrlEncoder.Default.Encode(trackName)}";
+            url += $"/{LastfmUrlExtensions.Encode(trackName)}";
         }
 
         return url;

--- a/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
+++ b/src/FMBot.Domain/Extensions/LastfmUrlExtensions.cs
@@ -4,7 +4,7 @@ namespace FMBot.Domain.Extensions;
 
 public static class LastfmUrlExtensions
 {
-	private static string Encode(string name) {
+	public static string Encode(string name) {
 		return HttpUtility.UrlEncode(name).Replace("%2b", "%252B");
 	}
 	


### PR DESCRIPTION
UrlEncoder.Default.Encode converts spaces to %20, not +. fmbot has been doing last.fm links inconsistent with their preferred format when it isn't using HttpUtility.UrlEncode (or replacing a resulting %20 with + when using UrlEncoder.Default.Encode).

this can be seen in commands like `.search`.

secondly, +s in last.fm artist/album/track names must be double-encoded.
https://github.com/gowon-bot/gowon/blob/256e728ab446dbfe942915acb94e494a4b6d37b0/src/helpers/lastfm/LastfmLinks.ts#L17

changes then -> than